### PR TITLE
chore: Add missing gasSpent property to the quote result

### DIFF
--- a/.changeset/large-melons-nail.md
+++ b/.changeset/large-melons-nail.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+Adds missing `gasSpent` property to the `getQuote` result

--- a/src/evm/api/quote.test.ts
+++ b/src/evm/api/quote.test.ts
@@ -32,6 +32,16 @@ describe('getQuote', () => {
     }
   })
 
+  it('should return gasSpent as a number on success', async () => {
+    const result = await getQuote(baseQuoteRequest)
+
+    expect(result.status).toBe('Success')
+    if (result.status === 'Success') {
+      expect(result.gasSpent).toBeTypeOf('number')
+      expect(result.gasSpent).toBeGreaterThan(0)
+    }
+  })
+
   it.skip('should return a quote when url is set to staging', async () => {
     const result = await getQuote({
       ...baseQuoteRequest,

--- a/src/evm/api/quote.ts
+++ b/src/evm/api/quote.ts
@@ -40,6 +40,8 @@ function quoteResponseSchema<Visualize extends boolean>(visualize?: Visualize) {
 
       amountIn: z.string(),
       assumedAmountOut: z.string(),
+
+      gasSpent: z.number(),
     })
     .transform((data) => ({
       ...data,


### PR DESCRIPTION
Adds missing `gasSpent` property to the quote result