### PR TITLE
Add collect minimum amount tolerance

### DIFF
--- a/.changeset/quiet-pandas-collect.md
+++ b/.changeset/quiet-pandas-collect.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+Add optional collect minimum amount tolerance to SushiSwap V3 position manager calldata generation.

--- a/src/evm/pool/sushiswap-v3/entities/NonfungiblePositionManager.test.ts
+++ b/src/evm/pool/sushiswap-v3/entities/NonfungiblePositionManager.test.ts
@@ -8,6 +8,7 @@ import {
 } from 'viem'
 import { describe, expect, it } from 'vitest'
 import { Amount } from '../../../../generic/currency/amount.js'
+import { Fraction } from '../../../../generic/math/fraction.js'
 import { Percent } from '../../../../generic/math/percent.js'
 import { multicallAbi_multicall } from '../../../abi/multicallAbi/multicallAbi_multicall.js'
 import { nonfungiblePositionManagerAbi_collect } from '../../../abi/nonfungiblePositionManagerAbi/nonfungiblePositionManagerAbi_collect.js'
@@ -249,6 +250,105 @@ describe('NonfungiblePositionManager', () => {
         '0xac9650d8000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001a00000000000000000000000000000000000000000000000000000000000000084fc6f78650000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffffffffffff00000000000000000000000000000000ffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004449404b7c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000064df2ab5bb00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000',
       )
       expect(value).toEqual('0x0')
+    })
+
+    it('applies minimum amount tolerance to eth unwraps and token sweeps', () => {
+      const { calldata, value } =
+        NonfungiblePositionManager.collectCallParameters(
+          {
+            tokenId,
+            expectedCurrencyOwed0: new Amount(token1, 2000n),
+            expectedCurrencyOwed1: new Amount(EvmNative.fromChainId(1), 1000n),
+            recipient,
+          },
+          {
+            minimumAmountTolerance: new Fraction({
+              numerator: 1n,
+              denominator: 1000n,
+            }),
+          },
+        )
+
+      const [[, encodedUnwrapParams, encodedSweepParams]] = decodeAbiParameters(
+        multicallAbi_multicall[0].inputs,
+        `0x${calldata.slice(10)}`,
+      )
+
+      const unwrapParams = decodeUnwrapParams(encodedUnwrapParams)
+      const sweepParams = decodeSweepParams(encodedSweepParams)
+
+      expect(unwrapParams).toEqual([999n, recipient])
+      expect(sweepParams).toEqual([token1.address, 1998n, recipient])
+      expect(value).toEqual('0x0')
+    })
+
+    it('applies minimum amount tolerance after aggregating collections', () => {
+      const { calldata, value } =
+        NonfungiblePositionManager.collectCallParameters(
+          [1, 2, 3].map((tokenId) => ({
+            tokenId,
+            expectedCurrencyOwed0: new Amount(token1, 1n),
+            expectedCurrencyOwed1: new Amount(EvmNative.fromChainId(1), 1n),
+            recipient,
+          })),
+          {
+            minimumAmountTolerance: new Fraction({
+              numerator: 1n,
+              denominator: 1000n,
+            }),
+          },
+        )
+
+      const [[, , , encodedUnwrapParams, encodedSweepParams]] =
+        decodeAbiParameters(
+          multicallAbi_multicall[0].inputs,
+          `0x${calldata.slice(10)}`,
+        )
+
+      const unwrapParams = decodeUnwrapParams(encodedUnwrapParams)
+      const sweepParams = decodeSweepParams(encodedSweepParams)
+
+      expect(unwrapParams).toEqual([2n, recipient])
+      expect(sweepParams).toEqual([token1.address, 2n, recipient])
+      expect(value).toEqual('0x0')
+    })
+
+    it('throws when minimum amount tolerance is greater than 100%', () => {
+      expect(() =>
+        NonfungiblePositionManager.collectCallParameters(
+          {
+            tokenId,
+            expectedCurrencyOwed0: new Amount(token1, 2000n),
+            expectedCurrencyOwed1: new Amount(EvmNative.fromChainId(1), 1000n),
+            recipient,
+          },
+          {
+            minimumAmountTolerance: new Fraction({
+              numerator: 1001n,
+              denominator: 1000n,
+            }),
+          },
+        ),
+      ).toThrow('INVALID_MINIMUM_AMOUNT_TOLERANCE')
+    })
+
+    it('throws when minimum amount tolerance has a zero denominator', () => {
+      expect(() =>
+        NonfungiblePositionManager.collectCallParameters(
+          {
+            tokenId,
+            expectedCurrencyOwed0: new Amount(token1, 2000n),
+            expectedCurrencyOwed1: new Amount(EvmNative.fromChainId(1), 1000n),
+            recipient,
+          },
+          {
+            minimumAmountTolerance: new Fraction({
+              numerator: 0n,
+              denominator: 0n,
+            }),
+          },
+        ),
+      ).toThrow('INVALID_MINIMUM_AMOUNT_TOLERANCE')
     })
 
     it('works with multiple collections', () => {

--- a/src/evm/pool/sushiswap-v3/entities/NonfungiblePositionManager.ts
+++ b/src/evm/pool/sushiswap-v3/entities/NonfungiblePositionManager.ts
@@ -331,10 +331,7 @@ export abstract class NonfungiblePositionManager {
     minimumAmountMultiplier?: Fraction,
   ): Hex[] {
     const calldatas: Hex[] = []
-    const nativeBalancesByRecipient = new Map<
-      string,
-      { currency: EvmCurrency; amount: bigint }
-    >()
+    const nativeBalancesByRecipient = new Map<string, bigint>()
     const sweepBalancesByRecipient = new Map<
       string,
       { token: EvmToken; amount: bigint; recipient: Hex }
@@ -367,10 +364,6 @@ export abstract class NonfungiblePositionManager {
           options.expectedCurrencyOwed0.currency.type === 'native'
             ? options.expectedCurrencyOwed0.amount
             : options.expectedCurrencyOwed1.amount
-        const ethCurrency =
-          options.expectedCurrencyOwed0.currency.type === 'native'
-            ? options.expectedCurrencyOwed0.currency
-            : options.expectedCurrencyOwed1.currency
         const token =
           options.expectedCurrencyOwed0.currency.type === 'native'
             ? (options.expectedCurrencyOwed1.currency as EvmToken)
@@ -381,11 +374,11 @@ export abstract class NonfungiblePositionManager {
             : options.expectedCurrencyOwed0.amount
 
         const currentNativeBalance =
-          nativeBalancesByRecipient.get(recipient)?.amount ?? 0n
-        nativeBalancesByRecipient.set(recipient, {
-          currency: ethCurrency,
-          amount: currentNativeBalance + ethAmount,
-        })
+          nativeBalancesByRecipient.get(recipient) ?? 0n
+        nativeBalancesByRecipient.set(
+          recipient,
+          currentNativeBalance + ethAmount,
+        )
 
         const balanceKey = `${token.address}-${recipient}`
         const accumulatedBalance = sweepBalancesByRecipient.get(balanceKey)
@@ -403,13 +396,13 @@ export abstract class NonfungiblePositionManager {
 
     for (const [
       recipient,
-      { currency, amount },
+      nativeAmount,
     ] of nativeBalancesByRecipient.entries()) {
       calldatas.push(
         Payments.encodeUnwrapWETH9(
           minimumAmountMultiplier
-            ? new Amount(currency, amount).mul(minimumAmountMultiplier).amount
-            : amount,
+            ? minimumAmountMultiplier.mul(nativeAmount).quotient
+            : nativeAmount,
           recipient as Hex,
         ),
       )
@@ -424,7 +417,7 @@ export abstract class NonfungiblePositionManager {
         Payments.encodeSweepToken(
           token,
           minimumAmountMultiplier
-            ? new Amount(token, amount).mul(minimumAmountMultiplier).amount
+            ? minimumAmountMultiplier.mul(amount).quotient
             : amount,
           recipient,
         ),

--- a/src/evm/pool/sushiswap-v3/entities/NonfungiblePositionManager.ts
+++ b/src/evm/pool/sushiswap-v3/entities/NonfungiblePositionManager.ts
@@ -7,6 +7,7 @@ import {
   zeroAddress,
 } from 'viem'
 import { Amount } from '../../../../generic/currency/amount.js'
+import { Fraction } from '../../../../generic/math/fraction.js'
 import type { Percent } from '../../../../generic/math/percent.js'
 import type { BigintIsh } from '../../../../generic/types/bigintish.js'
 import {
@@ -131,6 +132,13 @@ export interface CollectOptions {
    * The account that should receive the tokens.
    */
   recipient: string
+}
+
+export interface CollectCallParametersOptions {
+  /**
+   * Reduces the unwrap and sweep minimums by the provided tolerance.
+   */
+  minimumAmountTolerance?: Fraction
 }
 
 export interface NFTPermitOptions {
@@ -318,9 +326,15 @@ export abstract class NonfungiblePositionManager {
     }
   }
 
-  private static encodeCollect(collectOptions: CollectOptions[]): Hex[] {
+  private static encodeCollect(
+    collectOptions: CollectOptions[],
+    minimumAmountMultiplier?: Fraction,
+  ): Hex[] {
     const calldatas: Hex[] = []
-    const nativeBalancesByRecipient = new Map<string, bigint>()
+    const nativeBalancesByRecipient = new Map<
+      string,
+      { currency: EvmCurrency; amount: bigint }
+    >()
     const sweepBalancesByRecipient = new Map<
       string,
       { token: EvmToken; amount: bigint; recipient: Hex }
@@ -353,6 +367,10 @@ export abstract class NonfungiblePositionManager {
           options.expectedCurrencyOwed0.currency.type === 'native'
             ? options.expectedCurrencyOwed0.amount
             : options.expectedCurrencyOwed1.amount
+        const ethCurrency =
+          options.expectedCurrencyOwed0.currency.type === 'native'
+            ? options.expectedCurrencyOwed0.currency
+            : options.expectedCurrencyOwed1.currency
         const token =
           options.expectedCurrencyOwed0.currency.type === 'native'
             ? (options.expectedCurrencyOwed1.currency as EvmToken)
@@ -363,11 +381,11 @@ export abstract class NonfungiblePositionManager {
             : options.expectedCurrencyOwed0.amount
 
         const currentNativeBalance =
-          nativeBalancesByRecipient.get(recipient) ?? 0n
-        nativeBalancesByRecipient.set(
-          recipient,
-          currentNativeBalance + ethAmount,
-        )
+          nativeBalancesByRecipient.get(recipient)?.amount ?? 0n
+        nativeBalancesByRecipient.set(recipient, {
+          currency: ethCurrency,
+          amount: currentNativeBalance + ethAmount,
+        })
 
         const balanceKey = `${token.address}-${recipient}`
         const accumulatedBalance = sweepBalancesByRecipient.get(balanceKey)
@@ -385,9 +403,16 @@ export abstract class NonfungiblePositionManager {
 
     for (const [
       recipient,
-      nativeAmount,
+      { currency, amount },
     ] of nativeBalancesByRecipient.entries()) {
-      calldatas.push(Payments.encodeUnwrapWETH9(nativeAmount, recipient as Hex))
+      calldatas.push(
+        Payments.encodeUnwrapWETH9(
+          minimumAmountMultiplier
+            ? new Amount(currency, amount).mul(minimumAmountMultiplier).amount
+            : amount,
+          recipient as Hex,
+        ),
+      )
     }
 
     for (const {
@@ -395,7 +420,15 @@ export abstract class NonfungiblePositionManager {
       amount,
       recipient,
     } of sweepBalancesByRecipient.values()) {
-      calldatas.push(Payments.encodeSweepToken(token, amount, recipient))
+      calldatas.push(
+        Payments.encodeSweepToken(
+          token,
+          minimumAmountMultiplier
+            ? new Amount(token, amount).mul(minimumAmountMultiplier).amount
+            : amount,
+          recipient,
+        ),
+      )
     }
 
     return calldatas
@@ -403,9 +436,24 @@ export abstract class NonfungiblePositionManager {
 
   public static collectCallParameters(
     options: CollectOptions | CollectOptions[],
+    callOptions: CollectCallParametersOptions = {},
   ): MethodParameters {
+    if (callOptions.minimumAmountTolerance) {
+      invariant(
+        callOptions.minimumAmountTolerance.denominator > 0n &&
+          callOptions.minimumAmountTolerance.gte(0n) &&
+          callOptions.minimumAmountTolerance.lte(1n),
+        'INVALID_MINIMUM_AMOUNT_TOLERANCE',
+      )
+    }
+
+    const minimumAmountMultiplier = callOptions.minimumAmountTolerance
+      ? new Fraction({ numerator: 1 }).sub(callOptions.minimumAmountTolerance)
+      : undefined
+
     const calldatas: Hex[] = NonfungiblePositionManager.encodeCollect(
       Array.isArray(options) ? options : [options],
+      minimumAmountMultiplier,
     )
 
     return {


### PR DESCRIPTION
## Summary
- Add an optional `minimumAmountTolerance` parameter to `NonfungiblePositionManager.collectCallParameters`.
- Apply the tolerance after native unwrap and token sweep minimums are aggregated, preserving batched collect protection.
- Add regression coverage for tolerance application, aggregation rounding, and invalid tolerance inputs.

## Verification
- `pnpm exec vitest -c ./test/vitest.config.ts run src/evm/pool/sushiswap-v3/entities/NonfungiblePositionManager.test.ts`
- `pnpm typecheck`
- `pnpm lint:dryrun`
- `pnpm build`

Note: commands emitted an engine warning because this environment is Node v20.19.5 while the repo requests Node 22.x.