### PR TITLE
fix: type svm native address export

### DIFF
--- a/.changeset/soft-hounds-check.md
+++ b/.changeset/soft-hounds-check.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+Fix SVM native address declaration emit to use the public address type.

--- a/src/svm/config/simple-constants.ts
+++ b/src/svm/config/simple-constants.ts
@@ -1,3 +1,4 @@
-import { svmAddress } from '../currency/token.js'
+import { type SvmAddress, svmAddress } from '../currency/token.js'
 
-export const svmNativeAddress = svmAddress('11111111111111111111111111111111')
+export const svmNativeAddress: SvmAddress<'11111111111111111111111111111111'> =
+  svmAddress('11111111111111111111111111111111')


### PR DESCRIPTION
## Summary
- Annotates svmNativeAddress with the public SvmAddress type so generated declarations no longer reference @solana/addresses private dist paths for this export.
- Adds a patch changeset for sushi.

## Verification
- pnpm typecheck
- pnpm lint:dryrun
- pnpm build
- Inspected src/_types/svm/config/simple-constants.d.ts and confirmed it emits SvmAddress<'11111111111111111111111111111111'> from ../currency/token.js.

## GitHub connectivity
- git ls-remote and gh auth status succeeded.
- git pull --ff-only succeeded and fast-forwarded master before this branch was created.