### PR TITLE
fix: preserve stellar address subtype normalization

### DIFF
--- a/.changeset/quiet-starfishes-normalize.md
+++ b/.changeset/quiet-starfishes-normalize.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Preserve Stellar account and contract address types when normalizing addresses.

--- a/.changeset/stellar-address-validator.md
+++ b/.changeset/stellar-address-validator.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Add a general Stellar address validator for account and contract addresses.

--- a/src/generic/utils/normalize-address.test-d.ts
+++ b/src/generic/utils/normalize-address.test-d.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from '../../stellar/address.js'
+import { StellarChainId } from '../../stellar/chain/chains.js'
+import { normalizeAddress } from './normalize-address.js'
+
+describe('normalizeAddress types', () => {
+  it('preserves Stellar account and contract address types', () => {
+    const accountAddress =
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7' as StellarAccountAddress
+    const contractAddress =
+      'CCRSMJDITH3VK5QOGYCVZDAKIY5GL3RCG4TCVLIAVB662IW2V5KJGZGF' as StellarContractAddress
+
+    expectTypeOf(
+      normalizeAddress(StellarChainId.STELLAR, accountAddress),
+    ).toEqualTypeOf<StellarAccountAddress>()
+    expectTypeOf(
+      normalizeAddress(StellarChainId.STELLAR, contractAddress),
+    ).toEqualTypeOf<StellarContractAddress>()
+  })
+})

--- a/src/generic/utils/normalize-address.ts
+++ b/src/generic/utils/normalize-address.ts
@@ -14,32 +14,26 @@ import type { ChainId } from '../chain/chains.js'
 import type { AddressFor } from '../types/for-chain.js'
 import { assertNever } from './assert-never.js'
 
-export function normalizeAddress<TChainId extends ChainId>(
-  chainId: TChainId,
-  address: AddressFor<TChainId>,
-): AddressFor<TChainId> {
+export function normalizeAddress<
+  TChainId extends ChainId,
+  TAddress extends AddressFor<TChainId>,
+>(chainId: TChainId, address: TAddress): TAddress {
   if (isEvmChainId(chainId)) {
-    return normalizeEvmAddress(
-      address as AddressFor<EvmChainId>,
-    ) as AddressFor<TChainId>
+    return normalizeEvmAddress(address as AddressFor<EvmChainId>) as TAddress
   }
 
   if (isMvmChainId(chainId)) {
-    return normalizeMvmAddress(
-      address as AddressFor<MvmChainId>,
-    ) as AddressFor<TChainId>
+    return normalizeMvmAddress(address as AddressFor<MvmChainId>) as TAddress
   }
 
   if (isSvmChainId(chainId)) {
-    return normalizeSvmAddress(
-      address as AddressFor<SvmChainId>,
-    ) as AddressFor<TChainId>
+    return normalizeSvmAddress(address as AddressFor<SvmChainId>) as TAddress
   }
 
   if (isStellarChainId(chainId)) {
     return normalizeStellarAddress(
       address as AddressFor<StellarChainId>,
-    ) as AddressFor<TChainId>
+    ) as TAddress
   }
 
   assertNever(chainId, `normalizeAddress, unsupported chainId: ${chainId}`)

--- a/src/stellar/address.test.ts
+++ b/src/stellar/address.test.ts
@@ -21,10 +21,11 @@ describe('stellar addresses', () => {
     expect(isStellarContractAddress(contractAddress)).toBe(true)
   })
 
-  it('accepts both account and contract addresses as Stellar addresses', () => {
+  it('accepts account and contract addresses as Stellar addresses', () => {
     expect(isStellarAddress(accountAddress)).toBe(true)
     expect(isStellarAddress(contractAddress)).toBe(true)
     expect(isStellarAddress('0x1234')).toBe(false)
+    expect(isStellarAddress(`M${'A'.repeat(68)}`)).toBe(false)
   })
 
   it('normalizes account, contract, and chain addresses', () => {

--- a/src/stellar/address.ts
+++ b/src/stellar/address.ts
@@ -4,14 +4,14 @@ export type StellarAddress = StellarAccountAddress | StellarContractAddress
 export type StellarTxHash = string
 
 const stellarAccountAddressRegex = /^G[A-Z2-7]{55}$/
+const stellarContractAddressRegex = /^C[A-Z2-7]{55}$/
+const stellarAddressRegex = /^[GC][A-Z2-7]{55}$/
 
 export function isStellarAccountAddress(
   address: string,
 ): address is StellarAccountAddress {
   return stellarAccountAddressRegex.test(address)
 }
-
-const stellarContractAddressRegex = /^C[A-Z2-7]{55}$/
 
 export function isStellarContractAddress(
   address: string,
@@ -20,5 +20,5 @@ export function isStellarContractAddress(
 }
 
 export function isStellarAddress(address: string): address is StellarAddress {
-  return isStellarAccountAddress(address) || isStellarContractAddress(address)
+  return stellarAddressRegex.test(address)
 }


### PR DESCRIPTION
## Summary
- preserve the specific address subtype passed to normalizeAddress
- add a type regression test for Stellar account vs contract addresses
- add a patch changeset

## Verification
- pnpm lint:dryrun
- pnpm typecheck
- pnpm vitest -c ./test/vitest.config.ts run src/stellar/address.test.ts src/generic/utils/normalize-address.test-d.ts

Note: commands warn because local Node is v20.19.5 while the repo requests Node 22.x.