### PR TITLE
fix: preserve stellar address subtype normalization

### DIFF
--- a/.changeset/quiet-starfishes-normalize.md
+++ b/.changeset/quiet-starfishes-normalize.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Preserve Stellar account and contract address types when normalizing addresses.

--- a/.changeset/quiet-starfishes-normalize.md
+++ b/.changeset/quiet-starfishes-normalize.md
@@ -2,4 +2,4 @@
 'sushi': patch
 ---
 
-Preserve Stellar account and contract address types when normalizing addresses.
+Preserve address subtypes and allow normalizeAddress to infer chains by address format.

--- a/src/generic/utils/normalize-address.test-d.ts
+++ b/src/generic/utils/normalize-address.test-d.ts
@@ -1,12 +1,32 @@
 import { describe, expectTypeOf, it } from 'vitest'
+import { EvmChainId } from '../../evm/chain/chains.js'
+import type { EvmAddress } from '../../evm/currency/token.js'
 import type {
   StellarAccountAddress,
   StellarContractAddress,
 } from '../../stellar/address.js'
 import { StellarChainId } from '../../stellar/chain/chains.js'
+import { SvmChainId } from '../../svm/chain/chains.js'
+import type { SvmAddress } from '../../svm/currency/token.js'
 import { normalizeAddress } from './normalize-address.js'
 
 describe('normalizeAddress types', () => {
+  it('preserves EVM address types', () => {
+    const address = '0x0000000000000000000000000000000000000000' as EvmAddress
+
+    expectTypeOf(
+      normalizeAddress(EvmChainId.ETHEREUM, address),
+    ).toEqualTypeOf<EvmAddress>()
+  })
+
+  it('preserves SVM address types', () => {
+    const address = 'So11111111111111111111111111111111111111112' as SvmAddress
+
+    expectTypeOf(
+      normalizeAddress(SvmChainId.SOLANA, address),
+    ).toEqualTypeOf<SvmAddress>()
+  })
+
   it('preserves Stellar account and contract address types', () => {
     const accountAddress =
       'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7' as StellarAccountAddress
@@ -19,5 +39,30 @@ describe('normalizeAddress types', () => {
     expectTypeOf(
       normalizeAddress(StellarChainId.STELLAR, contractAddress),
     ).toEqualTypeOf<StellarContractAddress>()
+  })
+
+  it('preserves same-chain address unions', () => {
+    function normalizeStellarUnion(
+      address: StellarAccountAddress | StellarContractAddress,
+    ) {
+      expectTypeOf(
+        normalizeAddress(StellarChainId.STELLAR, address),
+      ).toEqualTypeOf<StellarAccountAddress | StellarContractAddress>()
+    }
+
+    expectTypeOf(normalizeStellarUnion).returns.toEqualTypeOf<void>()
+  })
+
+  it('preserves cross-chain address unions', () => {
+    function normalizeEvmOrSvmUnion(
+      chainId: typeof EvmChainId.ETHEREUM | typeof SvmChainId.SOLANA,
+      address: EvmAddress | SvmAddress,
+    ) {
+      expectTypeOf(normalizeAddress(chainId, address)).toEqualTypeOf<
+        EvmAddress | SvmAddress
+      >()
+    }
+
+    expectTypeOf(normalizeEvmOrSvmUnion).returns.toEqualTypeOf<void>()
   })
 })

--- a/src/generic/utils/normalize-address.test-d.ts
+++ b/src/generic/utils/normalize-address.test-d.ts
@@ -1,6 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { EvmChainId } from '../../evm/chain/chains.js'
 import type { EvmAddress } from '../../evm/currency/token.js'
+import type { MvmAddress } from '../../mvm/currency/token.js'
 import type {
   StellarAccountAddress,
   StellarContractAddress,
@@ -63,6 +64,47 @@ describe('normalizeAddress types', () => {
       >()
     }
 
+    expectTypeOf(normalizeEvmOrSvmUnion).returns.toEqualTypeOf<void>()
+  })
+
+  it('preserves address types without chain ids', () => {
+    const evmAddress =
+      '0x0000000000000000000000000000000000000000' as EvmAddress
+    const mvmAddress = '0x1::coin::T' as MvmAddress
+    const svmAddress =
+      'So11111111111111111111111111111111111111112' as SvmAddress
+    const stellarAccountAddress =
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7' as StellarAccountAddress
+    const stellarContractAddress =
+      'CCRSMJDITH3VK5QOGYCVZDAKIY5GL3RCG4TCVLIAVB662IW2V5KJGZGF' as StellarContractAddress
+
+    expectTypeOf(normalizeAddress(evmAddress)).toEqualTypeOf<EvmAddress>()
+    expectTypeOf(normalizeAddress(mvmAddress)).toEqualTypeOf<MvmAddress>()
+    expectTypeOf(normalizeAddress(svmAddress)).toEqualTypeOf<SvmAddress>()
+    expectTypeOf(
+      normalizeAddress(stellarAccountAddress),
+    ).toEqualTypeOf<StellarAccountAddress>()
+    expectTypeOf(
+      normalizeAddress(stellarContractAddress),
+    ).toEqualTypeOf<StellarContractAddress>()
+  })
+
+  it('preserves address unions without chain ids', () => {
+    function normalizeStellarUnion(
+      address: StellarAccountAddress | StellarContractAddress,
+    ) {
+      expectTypeOf(normalizeAddress(address)).toEqualTypeOf<
+        StellarAccountAddress | StellarContractAddress
+      >()
+    }
+
+    function normalizeEvmOrSvmUnion(address: EvmAddress | SvmAddress) {
+      expectTypeOf(normalizeAddress(address)).toEqualTypeOf<
+        EvmAddress | SvmAddress
+      >()
+    }
+
+    expectTypeOf(normalizeStellarUnion).returns.toEqualTypeOf<void>()
     expectTypeOf(normalizeEvmOrSvmUnion).returns.toEqualTypeOf<void>()
   })
 })

--- a/src/generic/utils/normalize-address.test-d.ts
+++ b/src/generic/utils/normalize-address.test-d.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from '../../stellar/address.js'
+import { StellarChainId } from '../../stellar/chain/chains.js'
+import { normalizeAddress } from './normalize-address.js'
+
+describe('normalizeAddress types', () => {
+  it('preserves Stellar account and contract address types', () => {
+    const accountAddress =
+      'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN7' as StellarAccountAddress
+    const contractAddress =
+      'CCRSMJDITH3VK5QOGYCVZDAKIY5GL3RCG4TCVLIAVB662IW2V5KJGZGF' as StellarContractAddress
+
+    expectTypeOf(
+      normalizeAddress(StellarChainId.STELLAR, accountAddress),
+    ).toEqualTypeOf<StellarAccountAddress>()
+    expectTypeOf(
+      normalizeAddress(StellarChainId.STELLAR, contractAddress),
+    ).toEqualTypeOf<StellarContractAddress>()
+  })
+})

--- a/src/generic/utils/normalize-address.test.ts
+++ b/src/generic/utils/normalize-address.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import type { EvmAddress } from '../../evm/currency/token.js'
+import type { MvmAddress } from '../../mvm/currency/token.js'
+import type { StellarContractAddress } from '../../stellar/address.js'
+import type { SvmAddress } from '../../svm/currency/token.js'
+import { normalizeAddress } from './normalize-address.js'
+
+describe('normalizeAddress', () => {
+  it('normalizes addresses without chain ids by address format', () => {
+    expect(
+      normalizeAddress(
+        '0x000000000000000000000000000000000000dEaD' as EvmAddress,
+      ),
+    ).toBe('0x000000000000000000000000000000000000dead')
+
+    const mvmAddress = '0xABC::Coin::T' as MvmAddress
+    expect(normalizeAddress(mvmAddress)).toBe(mvmAddress)
+
+    const svmAddress =
+      'So11111111111111111111111111111111111111112' as SvmAddress
+    expect(normalizeAddress(svmAddress)).toBe(svmAddress)
+
+    expect(
+      normalizeAddress(
+        'ccrsmjdith3vk5qogycvzdakiy5gl3rcg4tcvliavb662iw2v5kjgzgf' as StellarContractAddress,
+      ),
+    ).toBe('CCRSMJDITH3VK5QOGYCVZDAKIY5GL3RCG4TCVLIAVB662IW2V5KJGZGF')
+  })
+})

--- a/src/generic/utils/normalize-address.ts
+++ b/src/generic/utils/normalize-address.ts
@@ -1,40 +1,91 @@
+import { isAddress as isSvmAddress } from '@solana/addresses'
+import { isAddress as isEvmAddress } from 'viem'
 import type { EvmChainId } from '../../evm/chain/chains.js'
 import { isEvmChainId } from '../../evm/chain/chains.js'
+import type { EvmAddress } from '../../evm/currency/token.js'
 import { normalizeEvmAddress } from '../../evm/utils/normalize-address.js'
 import type { MvmChainId } from '../../mvm/chain/chains.js'
 import { isMvmChainId } from '../../mvm/chain/chains.js'
+import type { MvmAddress } from '../../mvm/currency/token.js'
 import { normalizeMvmAddress } from '../../mvm/utils/normalize-address.js'
+import { isStellarAddress, type StellarAddress } from '../../stellar/address.js'
 import type { StellarChainId } from '../../stellar/chain/chains.js'
 import { isStellarChainId } from '../../stellar/chain/chains.js'
 import { normalizeStellarAddress } from '../../stellar/utils/normalize-address.js'
 import type { SvmChainId } from '../../svm/chain/chains.js'
 import { isSvmChainId } from '../../svm/chain/chains.js'
+import type { SvmAddress } from '../../svm/currency/token.js'
 import { normalizeSvmAddress } from '../../svm/utils/normalize-address.js'
 import type { ChainId } from '../chain/chains.js'
 import type { AddressFor } from '../types/for-chain.js'
 import { assertNever } from './assert-never.js'
 
+type AnyAddress = AddressFor<ChainId>
+
+export function normalizeAddress<TAddress extends AnyAddress>(
+  address: TAddress,
+): TAddress
 export function normalizeAddress<
   TChainId extends ChainId,
   TAddress extends AddressFor<TChainId>,
->(chainId: TChainId, address: TAddress): TAddress {
+>(chainId: TChainId, address: TAddress): TAddress
+export function normalizeAddress(
+  chainIdOrAddress: ChainId | AnyAddress,
+  address?: AnyAddress,
+): AnyAddress {
+  if (address === undefined) {
+    if (typeof chainIdOrAddress !== 'string') {
+      throw new Error(
+        `normalizeAddress, unsupported address: ${chainIdOrAddress}`,
+      )
+    }
+
+    return normalizeAddressByFormat(chainIdOrAddress)
+  }
+
+  return normalizeAddressByChainId(chainIdOrAddress as ChainId, address)
+}
+
+function normalizeAddressByChainId(chainId: ChainId, address: AnyAddress) {
   if (isEvmChainId(chainId)) {
-    return normalizeEvmAddress(address as AddressFor<EvmChainId>) as TAddress
+    return normalizeEvmAddress(address as AddressFor<EvmChainId>)
   }
 
   if (isMvmChainId(chainId)) {
-    return normalizeMvmAddress(address as AddressFor<MvmChainId>) as TAddress
+    return normalizeMvmAddress(address as AddressFor<MvmChainId>)
   }
 
   if (isSvmChainId(chainId)) {
-    return normalizeSvmAddress(address as AddressFor<SvmChainId>) as TAddress
+    return normalizeSvmAddress(address as AddressFor<SvmChainId>)
   }
 
   if (isStellarChainId(chainId)) {
-    return normalizeStellarAddress(
-      address as AddressFor<StellarChainId>,
-    ) as TAddress
+    return normalizeStellarAddress(address as AddressFor<StellarChainId>)
   }
 
   assertNever(chainId, `normalizeAddress, unsupported chainId: ${chainId}`)
+}
+
+function normalizeAddressByFormat(address: AnyAddress): AnyAddress {
+  if (isMvmAddress(address)) {
+    return normalizeMvmAddress(address)
+  }
+
+  if (isEvmAddress(address, { strict: false })) {
+    return normalizeEvmAddress(address as EvmAddress)
+  }
+
+  if (isSvmAddress(address)) {
+    return normalizeSvmAddress(address as SvmAddress)
+  }
+
+  if (isStellarAddress(address.toUpperCase())) {
+    return normalizeStellarAddress(address as StellarAddress)
+  }
+
+  throw new Error(`normalizeAddress, unsupported address: ${address}`)
+}
+
+function isMvmAddress(address: string): address is MvmAddress {
+  return /^0x([^:]+)::([^:]+)::([^:]+)$/.test(address)
 }

--- a/src/generic/utils/normalize-address.ts
+++ b/src/generic/utils/normalize-address.ts
@@ -14,32 +14,26 @@ import type { ChainId } from '../chain/chains.js'
 import type { AddressFor } from '../types/for-chain.js'
 import { assertNever } from './assert-never.js'
 
-export function normalizeAddress<TChainId extends ChainId>(
-  chainId: TChainId,
-  address: AddressFor<TChainId>,
-): AddressFor<TChainId> {
+export function normalizeAddress<
+  TChainId extends ChainId,
+  TAddress extends AddressFor<TChainId>,
+>(chainId: TChainId, address: TAddress): TAddress {
   if (isEvmChainId(chainId)) {
-    return normalizeEvmAddress(
-      address as AddressFor<EvmChainId>,
-    ) as AddressFor<TChainId>
+    return normalizeEvmAddress(address as AddressFor<EvmChainId>) as TAddress
   }
 
   if (isMvmChainId(chainId)) {
-    return normalizeMvmAddress(
-      address as AddressFor<MvmChainId>,
-    ) as AddressFor<TChainId>
+    return normalizeMvmAddress(address as AddressFor<MvmChainId>) as TAddress
   }
 
   if (isSvmChainId(chainId)) {
-    return normalizeSvmAddress(
-      address as AddressFor<SvmChainId>,
-    ) as AddressFor<TChainId>
+    return normalizeSvmAddress(address as AddressFor<SvmChainId>) as TAddress
   }
 
   if (isStellarChainId(chainId)) {
     return normalizeStellarAddress(
       address as AddressFor<StellarChainId>,
-    ) as AddressFor<TChainId>
+    ) as TAddress
   }
 
   assertNever(chainId, `normalizeAddress, unsupported chainId: ${chainId}`)

--- a/src/generic/utils/normalize-address.ts
+++ b/src/generic/utils/normalize-address.ts
@@ -1,12 +1,10 @@
-import { isAddress as isSvmAddress } from '@solana/addresses'
-import { isAddress as isEvmAddress } from 'viem'
 import type { EvmChainId } from '../../evm/chain/chains.js'
 import { isEvmChainId } from '../../evm/chain/chains.js'
-import type { EvmAddress } from '../../evm/currency/token.js'
+import { type EvmAddress, isEvmAddress } from '../../evm/currency/token.js'
 import { normalizeEvmAddress } from '../../evm/utils/normalize-address.js'
 import type { MvmChainId } from '../../mvm/chain/chains.js'
 import { isMvmChainId } from '../../mvm/chain/chains.js'
-import type { MvmAddress } from '../../mvm/currency/token.js'
+import { isMvmAddress } from '../../mvm/currency/token.js'
 import { normalizeMvmAddress } from '../../mvm/utils/normalize-address.js'
 import { isStellarAddress, type StellarAddress } from '../../stellar/address.js'
 import type { StellarChainId } from '../../stellar/chain/chains.js'
@@ -14,7 +12,7 @@ import { isStellarChainId } from '../../stellar/chain/chains.js'
 import { normalizeStellarAddress } from '../../stellar/utils/normalize-address.js'
 import type { SvmChainId } from '../../svm/chain/chains.js'
 import { isSvmChainId } from '../../svm/chain/chains.js'
-import type { SvmAddress } from '../../svm/currency/token.js'
+import { isSvmAddress, type SvmAddress } from '../../svm/currency/token.js'
 import { normalizeSvmAddress } from '../../svm/utils/normalize-address.js'
 import type { ChainId } from '../chain/chains.js'
 import type { AddressFor } from '../types/for-chain.js'
@@ -74,7 +72,7 @@ function normalizeAddressByFormat(
     return normalizeMvmAddress(address)
   }
 
-  if (isEvmAddress(address, { strict: false })) {
+  if (isEvmAddress(address)) {
     return normalizeEvmAddress(address as EvmAddress)
   }
 
@@ -87,8 +85,4 @@ function normalizeAddressByFormat(
   }
 
   throw new Error(`normalizeAddress, unsupported address: ${address}`)
-}
-
-function isMvmAddress(address: string): address is MvmAddress {
-  return /^0x([^:]+)::([^:]+)::([^:]+)$/.test(address)
 }

--- a/src/generic/utils/normalize-address.ts
+++ b/src/generic/utils/normalize-address.ts
@@ -20,9 +20,7 @@ import type { ChainId } from '../chain/chains.js'
 import type { AddressFor } from '../types/for-chain.js'
 import { assertNever } from './assert-never.js'
 
-type AnyAddress = AddressFor<ChainId>
-
-export function normalizeAddress<TAddress extends AnyAddress>(
+export function normalizeAddress<TAddress extends AddressFor<ChainId>>(
   address: TAddress,
 ): TAddress
 export function normalizeAddress<
@@ -30,9 +28,9 @@ export function normalizeAddress<
   TAddress extends AddressFor<TChainId>,
 >(chainId: TChainId, address: TAddress): TAddress
 export function normalizeAddress(
-  chainIdOrAddress: ChainId | AnyAddress,
-  address?: AnyAddress,
-): AnyAddress {
+  chainIdOrAddress: ChainId | AddressFor<ChainId>,
+  address?: AddressFor<ChainId>,
+): AddressFor<ChainId> {
   if (address === undefined) {
     if (typeof chainIdOrAddress !== 'string') {
       throw new Error(
@@ -46,7 +44,10 @@ export function normalizeAddress(
   return normalizeAddressByChainId(chainIdOrAddress as ChainId, address)
 }
 
-function normalizeAddressByChainId(chainId: ChainId, address: AnyAddress) {
+function normalizeAddressByChainId(
+  chainId: ChainId,
+  address: AddressFor<ChainId>,
+) {
   if (isEvmChainId(chainId)) {
     return normalizeEvmAddress(address as AddressFor<EvmChainId>)
   }
@@ -66,7 +67,9 @@ function normalizeAddressByChainId(chainId: ChainId, address: AnyAddress) {
   assertNever(chainId, `normalizeAddress, unsupported chainId: ${chainId}`)
 }
 
-function normalizeAddressByFormat(address: AnyAddress): AnyAddress {
+function normalizeAddressByFormat(
+  address: AddressFor<ChainId>,
+): AddressFor<ChainId> {
   if (isMvmAddress(address)) {
     return normalizeMvmAddress(address)
   }


### PR DESCRIPTION
## Summary
- preserve the specific address subtype passed to normalizeAddress
- add an overload so normalizeAddress can be called with only an address
- infer normalization by address format for EVM, MVM, SVM, and Stellar addresses
- add runtime and type regression coverage, including same-chain and cross-chain unions
- add a patch changeset

## Verification
- pnpm lint:dryrun
- pnpm typecheck
- pnpm vitest -c ./test/vitest.config.ts run src/generic/utils/normalize-address.test.ts src/generic/utils/normalize-address.test-d.ts src/stellar/address.test.ts

Note: commands warn because local Node is v20.19.5 while the repo requests Node 22.x.