### PR TITLE
fix: use Goldsky Katana subgraphs

### DIFF
--- a/.changeset/goldsky-katana-subgraphs.md
+++ b/.changeset/goldsky-katana-subgraphs.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Use Goldsky-hosted Katana V2 and V3 subgraphs.

--- a/src/evm/config/subgraphs/subgraphs/sushiswap-v2.ts
+++ b/src/evm/config/subgraphs/subgraphs/sushiswap-v2.ts
@@ -20,10 +20,6 @@ const SUSHISWAP_V2_DECENTRALIZED_DEPLOYMENT_IDS = {
   [EvmChainId.SONIC]: `QmTnVXE9wVJRDaxNdW1hnvzi8Cj1XBv3cMGXz6gHLacMVJ`,
 } as const satisfies Partial<Record<SushiSwapV2ChainId, string>>
 
-const SUSHISWAP_V2_DECENTRALIZED_SUBGRAPH_IDS = {
-  [EvmChainId.KATANA]: `FYBTPY5uYPZ3oXpEriw9Pzn8RH9S1m7tpNwBwaNMuTNq`,
-} as const satisfies Partial<Record<SushiSwapV2ChainId, string>>
-
 const SUSHISWAP_V2_OTHER_URLS = {
   [EvmChainId.ARBITRUM_NOVA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-0m/v2-arbitrum-nova/gn`,
   [EvmChainId.FILECOIN]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v2-filecoin/gn`,
@@ -31,12 +27,13 @@ const SUSHISWAP_V2_OTHER_URLS = {
   [EvmChainId.SKALE_EUROPA]: `${SKALE_HOST}/sushi/v2-skale-europa`,
   [EvmChainId.ROOTSTOCK]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v2-rootstock/gn`,
   [EvmChainId.HEMI]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v2-hemi/gn`,
+  [EvmChainId.KATANA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v2-katana/gn`,
 } as const satisfies Partial<Record<SushiSwapV2ChainId, string>>
 
 export const getSushiSwapV2SubgraphUrl = getSubgraphUrlWrapper({
-  decentralizedIds: {
-    ...wrapAsIdType(SUSHISWAP_V2_DECENTRALIZED_DEPLOYMENT_IDS, 'deploymentId'),
-    ...wrapAsIdType(SUSHISWAP_V2_DECENTRALIZED_SUBGRAPH_IDS, 'subgraphId'),
-  },
+  decentralizedIds: wrapAsIdType(
+    SUSHISWAP_V2_DECENTRALIZED_DEPLOYMENT_IDS,
+    'deploymentId',
+  ),
   otherUrls: SUSHISWAP_V2_OTHER_URLS,
 })<SushiSwapV2ChainId, 'PARTIAL'>()

--- a/src/evm/config/subgraphs/subgraphs/sushiswap-v3.ts
+++ b/src/evm/config/subgraphs/subgraphs/sushiswap-v3.ts
@@ -19,10 +19,6 @@ const SUSHISWAP_V3_DECENTRALIZED_DEPLOYMENT_IDS = {
   [EvmChainId.SONIC]: `Qmaa6gJsqzeSnDBjq4NnwerMGMSaSDLqRMDkrevGXwVUt1`,
 } as const satisfies Partial<Record<SushiSwapV3ChainId, string>>
 
-const SUSHISWAP_V3_DECENTRALIZED_SUBGRAPH_IDS = {
-  [EvmChainId.KATANA]: `2YG7eSFHx1Wm9SHKdcrM8HR23JQpVe8fNNdmDHMXyVYR`,
-} as const satisfies Partial<Record<SushiSwapV3ChainId, string>>
-
 const SUSHISWAP_V3_OTHER_URLS = {
   [EvmChainId.ARBITRUM_NOVA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushi-v3/v3-arbitrum-nova/gn`,
   [EvmChainId.FILECOIN]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v3-filecoin/gn`,
@@ -30,12 +26,13 @@ const SUSHISWAP_V3_OTHER_URLS = {
   [EvmChainId.SKALE_EUROPA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v3-skale-europa-2/gn`,
   [EvmChainId.ROOTSTOCK]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v3-rootstock-3/gn`,
   [EvmChainId.HEMI]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v3-hemi/gn`,
+  [EvmChainId.KATANA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/v3-katana/gn`,
 } as const satisfies Partial<Record<SushiSwapV3ChainId, string>>
 
 export const getSushiSwapV3SubgraphUrl = getSubgraphUrlWrapper({
-  decentralizedIds: {
-    ...wrapAsIdType(SUSHISWAP_V3_DECENTRALIZED_DEPLOYMENT_IDS, 'deploymentId'),
-    ...wrapAsIdType(SUSHISWAP_V3_DECENTRALIZED_SUBGRAPH_IDS, 'subgraphId'),
-  },
+  decentralizedIds: wrapAsIdType(
+    SUSHISWAP_V3_DECENTRALIZED_DEPLOYMENT_IDS,
+    'deploymentId',
+  ),
   otherUrls: SUSHISWAP_V3_OTHER_URLS,
 })<SushiSwapV3ChainId, 'PARTIAL'>()


### PR DESCRIPTION
## Summary
- switch Katana SushiSwap V2 and V3 subgraph URLs to Goldsky-hosted endpoints
- add a patch changeset
- leave Katana blocks unchanged per scope

## Verification
- pnpm typecheck
- pnpm lint:dryrun