### PR TITLE
feat: add generic currency factories

### DIFF
--- a/.changeset/cool-rice-build.md
+++ b/.changeset/cool-rice-build.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Add generic currency factory helpers for native currencies and tokens.

--- a/src/evm/currency/currency.ts
+++ b/src/evm/currency/currency.ts
@@ -6,7 +6,7 @@ import { type EvmToken, serializedEvmTokenSchema } from './token.js'
 
 export type EvmCurrency<
   TMetadata extends CurrencyMetadata = Record<string, unknown>,
-> = EvmToken<TMetadata> | EvmNative
+> = EvmToken<TMetadata> | EvmNative<TMetadata>
 
 export const serializedEvmCurrencySchema = <
   TMetadata extends {} = CurrencyMetadata,

--- a/src/generic/currency/currency.test-d.ts
+++ b/src/generic/currency/currency.test-d.ts
@@ -16,6 +16,7 @@ import { MvmToken } from '../../mvm/currency/token.js'
 import {
   type SvmAddress,
   type SvmChainId,
+  type SvmCurrency,
   SvmNative,
   SvmToken,
 } from '../../svm/index.js'
@@ -196,6 +197,46 @@ describe('generic/currency/currency.ts types', () => {
       expectTypeOf(mockEvmCurrency)
         .extract<{ isToken: false }>()
         .toEqualTypeOf<EvmNative>()
+    })
+  })
+
+  describe('metadata generics', () => {
+    type Metadata = {
+      coingeckoId: string
+      verified: boolean
+    }
+
+    it('should preserve metadata on generic currency variants', () => {
+      const mockCurrency = {} as Currency<EvmChainId, Metadata>
+
+      expectTypeOf(mockCurrency)
+        .extract<{ isNative: true }>()
+        .toEqualTypeOf<Native<EvmChainId, Metadata>>()
+      expectTypeOf(mockCurrency)
+        .extract<{ isToken: true }>()
+        .toEqualTypeOf<Token<EvmChainId, string, Metadata>>()
+    })
+
+    it('should preserve metadata on EVM currency variants', () => {
+      const mockCurrency = {} as EvmCurrency<Metadata>
+
+      expectTypeOf(mockCurrency)
+        .extract<{ isNative: true }>()
+        .toEqualTypeOf<EvmNative<Metadata>>()
+      expectTypeOf(mockCurrency)
+        .extract<{ isToken: true }>()
+        .toEqualTypeOf<EvmToken<Metadata>>()
+    })
+
+    it('should preserve metadata on SVM currency variants', () => {
+      const mockCurrency = {} as SvmCurrency<Metadata>
+
+      expectTypeOf(mockCurrency)
+        .extract<{ isNative: true }>()
+        .toEqualTypeOf<SvmNative<Metadata>>()
+      expectTypeOf(mockCurrency)
+        .extract<{ isToken: true }>()
+        .toEqualTypeOf<SvmToken<Metadata>>()
     })
   })
 

--- a/src/generic/currency/currency.ts
+++ b/src/generic/currency/currency.ts
@@ -69,4 +69,4 @@ export abstract class BaseCurrency<
 export type Currency<
   TChainId extends ChainId = ChainId,
   TMetadata extends CurrencyMetadata = Record<string, unknown>,
-> = Native<TChainId> | Token<TChainId, string, TMetadata>
+> = Native<TChainId, TMetadata> | Token<TChainId, string, TMetadata>

--- a/src/generic/currency/for-chain.test-d.ts
+++ b/src/generic/currency/for-chain.test-d.ts
@@ -1,0 +1,224 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { EvmChainId } from '../../evm/chain/chains.js'
+import type { EvmNative } from '../../evm/currency/native.js'
+import type {
+  EvmAddress,
+  EvmToken,
+  EvmTokenOrigin,
+} from '../../evm/currency/token.js'
+import { MvmChainId } from '../../mvm/chain/chains.js'
+import type { MvmAddress, MvmToken } from '../../mvm/currency/token.js'
+import type { StellarContractAddress } from '../../stellar/address.js'
+import { StellarChainId } from '../../stellar/chain/chains.js'
+import type { StellarToken } from '../../stellar/currency/token.js'
+import { SvmChainId } from '../../svm/chain/chains.js'
+import type { SvmNative } from '../../svm/currency/native.js'
+import {
+  type SvmAddress,
+  type SvmToken,
+  svmAddress,
+} from '../../svm/currency/token.js'
+import type { NativeChainId } from '../types/for-chain.js'
+import {
+  getNativeFor,
+  getTokenFor,
+  type TokenConstructorDataFor,
+} from './for-chain.js'
+
+describe('generic/currency/for-chain.ts types', () => {
+  type Metadata = {
+    coingeckoId: string
+    verified: boolean
+  }
+
+  describe('getNativeFor', () => {
+    it('returns the native currency class for each supported native chain family', () => {
+      const metadata: Metadata = { coingeckoId: 'ethereum', verified: true }
+
+      expectTypeOf(getNativeFor(EvmChainId.ETHEREUM, metadata)).toEqualTypeOf<
+        EvmNative<Metadata>
+      >()
+      expectTypeOf(getNativeFor(SvmChainId.SOLANA, metadata)).toEqualTypeOf<
+        SvmNative<Metadata>
+      >()
+    })
+
+    it('returns a native union for native chain id unions', () => {
+      const chainId = {} as NativeChainId
+      const metadata: Metadata = { coingeckoId: 'native', verified: true }
+
+      expectTypeOf(getNativeFor(chainId, metadata)).toEqualTypeOf<
+        EvmNative<Metadata> | SvmNative<Metadata>
+      >()
+    })
+
+    it('rejects chain families without native currency classes', () => {
+      // @ts-expect-error MVM currently models currencies as tokens only.
+      getNativeFor(MvmChainId.APTOS, {})
+
+      // @ts-expect-error Stellar currently models currencies as tokens only.
+      getNativeFor(StellarChainId.STELLAR, {})
+    })
+  })
+
+  describe('TokenConstructorDataFor', () => {
+    it('matches EVM token constructor data without chainId', () => {
+      expectTypeOf<
+        TokenConstructorDataFor<EvmChainId, Metadata>
+      >().toMatchTypeOf<{
+        chainId?: EvmChainId
+        address: EvmAddress
+        symbol: string
+        name: string
+        decimals: number
+        metadata?: Metadata
+        origin?: EvmTokenOrigin | undefined
+      }>()
+
+      const data = {
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        symbol: 'TEST',
+        name: 'Test Token',
+        decimals: 18,
+        metadata: { coingeckoId: 'test-token', verified: true },
+      } satisfies TokenConstructorDataFor<EvmChainId, Metadata>
+
+      expectTypeOf(data.metadata).toMatchTypeOf<Metadata>()
+    })
+
+    it('matches MVM token constructor data without EVM/SVM/Stellar-only fields', () => {
+      const data = {
+        address: '0x1::aptos_coin::AptosCoin',
+        symbol: 'APT',
+        name: 'Aptos Coin',
+        decimals: 8,
+      } satisfies TokenConstructorDataFor<MvmChainId>
+
+      expectTypeOf(data.address).toMatchTypeOf<MvmAddress>()
+
+      const dataWithOrigin = {
+        address: '0x1::aptos_coin::AptosCoin',
+        symbol: 'APT',
+        name: 'Aptos Coin',
+        decimals: 8,
+        // @ts-expect-error origin is not part of MVM token constructor data.
+        origin: 'native',
+      } satisfies TokenConstructorDataFor<MvmChainId>
+
+      void dataWithOrigin
+    })
+
+    it('matches SVM token constructor data and preserves branded addresses', () => {
+      const data = {
+        address: svmAddress('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+        metadata: { coingeckoId: 'usd-coin', verified: true },
+      } satisfies TokenConstructorDataFor<SvmChainId, Metadata>
+
+      expectTypeOf(data.address).toMatchTypeOf<SvmAddress>()
+      expectTypeOf(data.metadata).toMatchTypeOf<Metadata>()
+    })
+
+    it('matches Stellar token constructor data including issuer and origin', () => {
+      const data = {
+        address: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA',
+        issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
+        symbol: 'XLM',
+        name: 'XLM',
+        decimals: 7,
+        origin: 'stellar.org',
+      } satisfies TokenConstructorDataFor<StellarChainId>
+
+      expectTypeOf(data.address).toMatchTypeOf<StellarContractAddress>()
+      expectTypeOf(data.origin).toMatchTypeOf<string>()
+    })
+
+    it('accepts chainId for compatibility', () => {
+      const dataWithChainId = {
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        symbol: 'TEST',
+        name: 'Test Token',
+        decimals: 18,
+        chainId: EvmChainId.ETHEREUM,
+      } satisfies TokenConstructorDataFor<EvmChainId>
+
+      void dataWithChainId
+    })
+  })
+
+  describe('getTokenFor', () => {
+    it('returns the token class selected by the chain id', () => {
+      expectTypeOf(
+        getTokenFor(EvmChainId.ETHEREUM, {
+          chainId: EvmChainId.POLYGON,
+          address: '0x1234567890abcdef1234567890abcdef12345678',
+          symbol: 'TEST',
+          name: 'Test Token',
+          decimals: 18,
+          metadata: { coingeckoId: 'test-token', verified: true },
+        }),
+      ).toEqualTypeOf<EvmToken<Metadata>>()
+
+      expectTypeOf(
+        getTokenFor(MvmChainId.APTOS, {
+          address: '0x1::aptos_coin::AptosCoin',
+          symbol: 'APT',
+          name: 'Aptos Coin',
+          decimals: 8,
+        }),
+      ).toEqualTypeOf<MvmToken<Record<string, unknown>>>()
+
+      expectTypeOf(
+        getTokenFor(SvmChainId.SOLANA, {
+          address: svmAddress('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+          metadata: { coingeckoId: 'usd-coin', verified: true },
+        }),
+      ).toEqualTypeOf<SvmToken<Metadata>>()
+
+      expectTypeOf(
+        getTokenFor(StellarChainId.STELLAR, {
+          address: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA',
+          symbol: 'XLM',
+          name: 'XLM',
+          decimals: 7,
+        }),
+      ).toEqualTypeOf<StellarToken<Record<string, unknown>>>()
+    })
+
+    it('returns a token union for generic chain id unions', () => {
+      const chainId = {} as EvmChainId | SvmChainId
+      const data = {} as TokenConstructorDataFor<
+        EvmChainId | SvmChainId,
+        Metadata
+      >
+
+      expectTypeOf(getTokenFor(chainId, data)).toEqualTypeOf<
+        EvmToken<Metadata> | SvmToken<Metadata>
+      >()
+    })
+
+    it('rejects constructor data for a different chain family', () => {
+      getTokenFor(SvmChainId.SOLANA, {
+        // @ts-expect-error SVM token data requires an SVM address.
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        symbol: 'TEST',
+        name: 'Test Token',
+        decimals: 18,
+      })
+
+      getTokenFor(MvmChainId.APTOS, {
+        address: '0x1::aptos_coin::AptosCoin',
+        symbol: 'APT',
+        name: 'Aptos Coin',
+        decimals: 8,
+        // @ts-expect-error issuer is Stellar-specific token data.
+        issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
+      })
+    })
+  })
+})

--- a/src/generic/currency/for-chain.test.ts
+++ b/src/generic/currency/for-chain.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import { EvmChainId } from '../../evm/chain/chains.js'
+import { EvmNative } from '../../evm/currency/native.js'
+import { EvmToken } from '../../evm/currency/token.js'
+import { MvmChainId } from '../../mvm/chain/chains.js'
+import { MvmToken } from '../../mvm/currency/token.js'
+import { StellarChainId } from '../../stellar/chain/chains.js'
+import { StellarToken } from '../../stellar/currency/token.js'
+import { SvmChainId } from '../../svm/chain/chains.js'
+import { SvmNative } from '../../svm/currency/native.js'
+import { SvmToken, svmAddress } from '../../svm/currency/token.js'
+import { getNativeFor, getTokenFor } from './for-chain.js'
+
+describe('generic/currency/for-chain.ts', () => {
+  describe('getNativeFor', () => {
+    it('creates EVM native currencies with metadata', () => {
+      type Metadata = { verified: boolean }
+      const metadata: Metadata = { verified: true }
+
+      const native = getNativeFor(EvmChainId.ETHEREUM, metadata)
+
+      expect(native).toBeInstanceOf(EvmNative)
+      expect(native.chainId).toBe(EvmChainId.ETHEREUM)
+      expect(native.metadata).toBe(metadata)
+      expectTypeOf(native).toEqualTypeOf<EvmNative<Metadata>>()
+    })
+
+    it('creates SVM native currencies with metadata', () => {
+      type Metadata = { coingeckoId: string }
+      const metadata: Metadata = { coingeckoId: 'solana' }
+
+      const native = getNativeFor(SvmChainId.SOLANA, metadata)
+
+      expect(native).toBeInstanceOf(SvmNative)
+      expect(native.chainId).toBe(SvmChainId.SOLANA)
+      expect(native.metadata).toBe(metadata)
+      expectTypeOf(native).toEqualTypeOf<SvmNative<Metadata>>()
+    })
+  })
+
+  describe('getTokenFor', () => {
+    it('creates EVM tokens from constructor data', () => {
+      type Metadata = { logoUrl: string }
+      const metadata: Metadata = { logoUrl: 'https://example.com/token.png' }
+
+      const token = getTokenFor(EvmChainId.ETHEREUM, {
+        chainId: EvmChainId.POLYGON,
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        symbol: 'TEST',
+        name: 'Test Token',
+        decimals: 18,
+        metadata,
+      })
+
+      expect(token).toBeInstanceOf(EvmToken)
+      expect(token.chainId).toBe(EvmChainId.ETHEREUM)
+      expect(token.metadata).toBe(metadata)
+      expectTypeOf(token).toEqualTypeOf<EvmToken<Metadata>>()
+    })
+
+    it('creates MVM tokens from constructor data', () => {
+      const token = getTokenFor(MvmChainId.APTOS, {
+        address: '0x1::aptos_coin::AptosCoin',
+        symbol: 'APT',
+        name: 'Aptos Coin',
+        decimals: 8,
+      })
+
+      expect(token).toBeInstanceOf(MvmToken)
+      expect(token.chainId).toBe(MvmChainId.APTOS)
+      expectTypeOf(token).toEqualTypeOf<MvmToken<Record<string, unknown>>>()
+    })
+
+    it('creates SVM tokens from constructor data', () => {
+      type Metadata = { tags: string[] }
+      const metadata: Metadata = { tags: ['stablecoin'] }
+
+      const token = getTokenFor(SvmChainId.SOLANA, {
+        address: svmAddress('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v'),
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+        metadata,
+      })
+
+      expect(token).toBeInstanceOf(SvmToken)
+      expect(token.chainId).toBe(SvmChainId.SOLANA)
+      expect(token.metadata).toBe(metadata)
+      expectTypeOf(token).toEqualTypeOf<SvmToken<Metadata>>()
+    })
+
+    it('creates Stellar tokens from constructor data', () => {
+      const token = getTokenFor(StellarChainId.STELLAR, {
+        address: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA',
+        issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
+        symbol: 'XLM',
+        name: 'XLM',
+        decimals: 7,
+        origin: 'stellar.org',
+      })
+
+      expect(token).toBeInstanceOf(StellarToken)
+      expect(token.chainId).toBe(StellarChainId.STELLAR)
+      expect(token.origin).toBe('stellar.org')
+      expectTypeOf(token).toEqualTypeOf<StellarToken<Record<string, unknown>>>()
+    })
+  })
+})

--- a/src/generic/currency/for-chain.ts
+++ b/src/generic/currency/for-chain.ts
@@ -1,0 +1,133 @@
+import {
+  type EvmChainId,
+  getEvmChainById,
+  isEvmChainId,
+} from '../../evm/chain/chains.js'
+import { EvmNative } from '../../evm/currency/native.js'
+import { EvmToken } from '../../evm/currency/token.js'
+import { isMvmChainId, type MvmChainId } from '../../mvm/chain/chains.js'
+import { MvmToken } from '../../mvm/currency/token.js'
+import {
+  isStellarChainId,
+  type StellarChainId,
+} from '../../stellar/chain/chains.js'
+import { StellarToken } from '../../stellar/currency/token.js'
+import {
+  getSvmChainById,
+  isSvmChainId,
+  type SvmChainId,
+} from '../../svm/chain/chains.js'
+import { SvmNative } from '../../svm/currency/native.js'
+import { SvmToken } from '../../svm/currency/token.js'
+import type { ChainId } from '../chain/chains.js'
+import type { NativeChainId, NativeFor, TokenFor } from '../types/for-chain.js'
+import { assertNever } from '../utils/assert-never.js'
+import type { CurrencyMetadata } from './currency.js'
+
+type ConstructorData<T extends abstract new (...args: any) => any> =
+  ConstructorParameters<T>[0] extends { chainId: infer TChainId }
+    ? Omit<ConstructorParameters<T>[0], 'chainId'> & { chainId?: TChainId }
+    : never
+
+type EvmTokenConstructorData<TMetadata extends CurrencyMetadata> =
+  ConstructorData<typeof EvmToken<TMetadata>>
+type MvmTokenConstructorData<TMetadata extends CurrencyMetadata> =
+  ConstructorData<typeof MvmToken<TMetadata>>
+type SvmTokenConstructorData<TMetadata extends CurrencyMetadata> =
+  ConstructorData<typeof SvmToken<TMetadata>>
+type StellarTokenConstructorData<TMetadata extends CurrencyMetadata> =
+  ConstructorData<typeof StellarToken<TMetadata>>
+
+export type TokenConstructorDataFor<
+  TChainId extends ChainId,
+  TMetadata extends CurrencyMetadata = CurrencyMetadata,
+> = TChainId extends EvmChainId
+  ? EvmTokenConstructorData<TMetadata>
+  : TChainId extends MvmChainId
+    ? MvmTokenConstructorData<TMetadata>
+    : TChainId extends SvmChainId
+      ? SvmTokenConstructorData<TMetadata>
+      : TChainId extends StellarChainId
+        ? StellarTokenConstructorData<TMetadata>
+        : never
+
+export function getNativeFor<
+  TChainId extends NativeChainId,
+  TMetadata extends CurrencyMetadata,
+>(chainId: TChainId, metadata: TMetadata): NativeFor<TChainId, TMetadata> {
+  if (isEvmChainId(chainId)) {
+    const chain = getEvmChainById(chainId)
+
+    return new EvmNative({
+      chainId,
+      symbol: chain.viemChain.nativeCurrency.symbol,
+      name: chain.viemChain.nativeCurrency.name,
+      decimals: chain.viemChain.nativeCurrency.decimals,
+      metadata,
+    }) as NativeFor<TChainId, TMetadata>
+  }
+
+  if (isSvmChainId(chainId)) {
+    const chain = getSvmChainById(chainId)
+
+    return new SvmNative({
+      chainId,
+      symbol: chain.nativeCurrency.symbol,
+      name: chain.nativeCurrency.name,
+      decimals: chain.nativeCurrency.decimals,
+      metadata,
+    }) as NativeFor<TChainId, TMetadata>
+  }
+
+  assertNever(chainId, `getNativeFor, unsupported chainId: ${chainId}`)
+}
+
+export function getTokenFor<
+  TChainId extends ChainId,
+  TMetadata extends CurrencyMetadata = Record<string, unknown>,
+>(
+  chainId: TChainId,
+  data: TokenConstructorDataFor<TChainId, TMetadata>,
+): TokenFor<TChainId, TMetadata> {
+  if (isEvmChainId(chainId)) {
+    return new EvmToken({
+      ...data,
+      chainId,
+    } as ConstructorParameters<typeof EvmToken<TMetadata>>[0]) as TokenFor<
+      TChainId,
+      TMetadata
+    >
+  }
+
+  if (isMvmChainId(chainId)) {
+    return new MvmToken({
+      ...data,
+      chainId,
+    } as ConstructorParameters<typeof MvmToken<TMetadata>>[0]) as TokenFor<
+      TChainId,
+      TMetadata
+    >
+  }
+
+  if (isSvmChainId(chainId)) {
+    return new SvmToken({
+      ...data,
+      chainId,
+    } as ConstructorParameters<typeof SvmToken<TMetadata>>[0]) as TokenFor<
+      TChainId,
+      TMetadata
+    >
+  }
+
+  if (isStellarChainId(chainId)) {
+    return new StellarToken({
+      ...data,
+      chainId,
+    } as ConstructorParameters<typeof StellarToken<TMetadata>>[0]) as TokenFor<
+      TChainId,
+      TMetadata
+    >
+  }
+
+  assertNever(chainId, `getTokenFor, unsupported chainId: ${chainId}`)
+}

--- a/src/generic/currency/index.ts
+++ b/src/generic/currency/index.ts
@@ -1,5 +1,6 @@
 export * from './amount.js'
 export * from './currency.js'
+export * from './for-chain.js'
 export * from './native.js'
 export * from './price.js'
 export * from './serialized-currency.js'

--- a/src/generic/types/for-chain.test-d.ts
+++ b/src/generic/types/for-chain.test-d.ts
@@ -1,12 +1,111 @@
 import { describe, expectTypeOf, it } from 'vitest'
+import type { EvmChainId } from '../../evm/chain/chains.js'
+import type { EvmCurrency } from '../../evm/currency/currency.js'
+import type { EvmNative } from '../../evm/currency/native.js'
+import type { EvmToken } from '../../evm/currency/token.js'
+import type { MvmChainId } from '../../mvm/chain/chains.js'
+import type { MvmToken } from '../../mvm/currency/token.js'
 import type { StellarAddress } from '../../stellar/address.js'
 import type { StellarChainId } from '../../stellar/chain/chains.js'
+import type { StellarCurrency } from '../../stellar/currency/currency.js'
+import type { StellarToken } from '../../stellar/currency/token.js'
 import type { StellarID } from '../../stellar/types/id.js'
+import type { SvmCurrency } from '../../svm/currency/currency.js'
+import type { SvmNative } from '../../svm/currency/native.js'
+import type { SvmToken } from '../../svm/currency/token.js'
 import type { SvmChainId } from '../../svm/index.js'
 import type { SvmID } from '../../svm/types/id.js'
-import type { IDFor } from './for-chain.js'
+import type {
+  CurrencyFor,
+  IDFor,
+  NativeChainId,
+  NativeFor,
+  TokenFor,
+} from './for-chain.js'
 
 describe('generic/types/for-chain.ts types', () => {
+  type Metadata = {
+    coingeckoId: string
+    verified: boolean
+  }
+
+  describe('TokenFor', () => {
+    it('should return the correct token type for each chain family', () => {
+      expectTypeOf<TokenFor<EvmChainId, Metadata>>().toEqualTypeOf<
+        EvmToken<Metadata>
+      >()
+      expectTypeOf<TokenFor<MvmChainId, Metadata>>().toEqualTypeOf<
+        MvmToken<Metadata>
+      >()
+      expectTypeOf<TokenFor<SvmChainId, Metadata>>().toEqualTypeOf<
+        SvmToken<Metadata>
+      >()
+      expectTypeOf<TokenFor<StellarChainId, Metadata>>().toEqualTypeOf<
+        StellarToken<Metadata>
+      >()
+    })
+
+    it('should distribute over chain id unions', () => {
+      expectTypeOf<TokenFor<EvmChainId | SvmChainId, Metadata>>().toEqualTypeOf<
+        EvmToken<Metadata> | SvmToken<Metadata>
+      >()
+    })
+  })
+
+  describe('CurrencyFor', () => {
+    it('should return the correct currency type for each chain family', () => {
+      expectTypeOf<CurrencyFor<EvmChainId, Metadata>>().toEqualTypeOf<
+        EvmCurrency<Metadata>
+      >()
+      expectTypeOf<CurrencyFor<MvmChainId, Metadata>>().toEqualTypeOf<
+        MvmToken<Metadata>
+      >()
+      expectTypeOf<CurrencyFor<SvmChainId, Metadata>>().toEqualTypeOf<
+        SvmCurrency<Metadata>
+      >()
+      expectTypeOf<CurrencyFor<StellarChainId, Metadata>>().toEqualTypeOf<
+        StellarCurrency<Metadata>
+      >()
+    })
+
+    it('should distribute over chain id unions', () => {
+      expectTypeOf<
+        CurrencyFor<EvmChainId | SvmChainId, Metadata>
+      >().toEqualTypeOf<EvmCurrency<Metadata> | SvmCurrency<Metadata>>()
+    })
+  })
+
+  describe('NativeFor', () => {
+    it('should only support chain families with native currency classes', () => {
+      expectTypeOf<NativeChainId>().toEqualTypeOf<EvmChainId | SvmChainId>()
+      expectTypeOf<NativeFor<EvmChainId, Metadata>>().toEqualTypeOf<
+        EvmNative<Metadata>
+      >()
+      expectTypeOf<NativeFor<SvmChainId, Metadata>>().toEqualTypeOf<
+        SvmNative<Metadata>
+      >()
+      expectTypeOf<NativeFor<NativeChainId, Metadata>>().toEqualTypeOf<
+        EvmNative<Metadata> | SvmNative<Metadata>
+      >()
+    })
+
+    it('should reject token-only chain families', () => {
+      type NativeForMvm = NativeFor<
+        // @ts-expect-error MVM is intentionally excluded from NativeChainId.
+        MvmChainId,
+        Metadata
+      >
+      type NativeForStellar = NativeFor<
+        // @ts-expect-error Stellar is intentionally excluded from NativeChainId.
+        StellarChainId,
+        Metadata
+      >
+
+      expectTypeOf<NativeForMvm>().toEqualTypeOf<never>()
+      expectTypeOf<NativeForStellar>().toEqualTypeOf<never>()
+    })
+  })
+
   describe('IDFor', () => {
     it('should return the correct id type for SVM chains', () => {
       expectTypeOf<IDFor<SvmChainId>>().toEqualTypeOf<SvmID>()

--- a/src/generic/types/for-chain.ts
+++ b/src/generic/types/for-chain.ts
@@ -1,5 +1,6 @@
 import type { EvmChainId } from '../../evm/chain/chains.js'
 import type { EvmCurrency } from '../../evm/currency/currency.js'
+import type { EvmNative } from '../../evm/currency/native.js'
 import type {
   EvmAddress,
   EvmToken,
@@ -19,6 +20,7 @@ import type { StellarToken } from '../../stellar/currency/token.js'
 import type { StellarID } from '../../stellar/types/id.js'
 import type { SvmChainId } from '../../svm/chain/chains.js'
 import type { SvmCurrency } from '../../svm/currency/currency.js'
+import type { SvmNative } from '../../svm/currency/native.js'
 import type {
   SvmAddress,
   SvmToken,
@@ -53,6 +55,17 @@ export type CurrencyFor<
       : TChainId extends StellarChainId
         ? StellarCurrency<Metadata>
         : never
+
+export type NativeChainId = EvmChainId | SvmChainId
+
+export type NativeFor<
+  TChainId extends NativeChainId,
+  Metadata extends CurrencyMetadata = CurrencyMetadata,
+> = TChainId extends EvmChainId
+  ? EvmNative<Metadata>
+  : TChainId extends SvmChainId
+    ? SvmNative<Metadata>
+    : never
 
 export type AddressFor<TChainId extends ChainId> = TChainId extends EvmChainId
   ? EvmAddress

--- a/src/svm/currency/currency.ts
+++ b/src/svm/currency/currency.ts
@@ -6,7 +6,7 @@ import { type SvmToken, serializedSvmTokenSchema } from './token.js'
 
 export type SvmCurrency<
   TMetadata extends CurrencyMetadata = Record<string, unknown>,
-> = SvmToken<TMetadata> | SvmNative
+> = SvmToken<TMetadata> | SvmNative<TMetadata>
 
 export const serializedSvmCurrencySchema = <
   TMetadata extends {} = CurrencyMetadata,


### PR DESCRIPTION
## Summary
- Add generic getNativeFor and getTokenFor currency factory helpers
- Add NativeFor/NativeChainId and constructor data types for chain-specific tokens
- Preserve metadata generics on native currency aliases
- Add runtime and type coverage plus a patch changeset

## Verification
- pnpm typecheck
- pnpm vitest -c ./test/vitest.config.ts run src/generic/currency/for-chain.test.ts
- pnpm lint:dryrun