### PR TITLE
fix: accept generic token input types

### DIFF
--- a/src/generic/currency/for-chain.test-d.ts
+++ b/src/generic/currency/for-chain.test-d.ts
@@ -18,7 +18,7 @@ import {
   type SvmToken,
   svmAddress,
 } from '../../svm/currency/token.js'
-import type { NativeChainId } from '../types/for-chain.js'
+import type { AddressFor, NativeChainId, TokenFor } from '../types/for-chain.js'
 import {
   getNativeFor,
   getTokenFor,
@@ -199,6 +199,30 @@ describe('generic/currency/for-chain.ts types', () => {
 
       expectTypeOf(getTokenFor(chainId, data)).toEqualTypeOf<
         EvmToken<Metadata> | SvmToken<Metadata>
+      >()
+    })
+
+    it('accepts generic EVM/SVM token input with address derived from the chain id', () => {
+      type GenericTokenInput<TChainId extends EvmChainId | SvmChainId> = {
+        address: AddressFor<TChainId>
+        symbol: string
+        name: string
+        decimals: number
+        metadata: Metadata
+      }
+
+      function getGenericTokenFor<TChainId extends EvmChainId | SvmChainId>(
+        chainId: TChainId,
+        input: GenericTokenInput<TChainId>,
+      ) {
+        return getTokenFor(chainId, input)
+      }
+
+      const chainId = {} as EvmChainId | SvmChainId
+      const input = {} as GenericTokenInput<typeof chainId>
+
+      expectTypeOf(getGenericTokenFor(chainId, input)).toEqualTypeOf<
+        TokenFor<EvmChainId | SvmChainId, Metadata>
       >()
     })
 

--- a/src/generic/currency/for-chain.ts
+++ b/src/generic/currency/for-chain.ts
@@ -20,7 +20,12 @@ import {
 import { SvmNative } from '../../svm/currency/native.js'
 import { SvmToken } from '../../svm/currency/token.js'
 import type { ChainId } from '../chain/chains.js'
-import type { NativeChainId, NativeFor, TokenFor } from '../types/for-chain.js'
+import type {
+  AddressFor,
+  NativeChainId,
+  NativeFor,
+  TokenFor,
+} from '../types/for-chain.js'
 import { assertNever } from '../utils/assert-never.js'
 import type { CurrencyMetadata } from './currency.js'
 
@@ -38,18 +43,32 @@ type SvmTokenConstructorData<TMetadata extends CurrencyMetadata> =
 type StellarTokenConstructorData<TMetadata extends CurrencyMetadata> =
   ConstructorData<typeof StellarToken<TMetadata>>
 
+type GenericTokenConstructorData<
+  TChainId extends ChainId,
+  TMetadata extends CurrencyMetadata,
+> = {
+  chainId?: TChainId
+  address: AddressFor<TChainId>
+  symbol: string
+  name: string
+  decimals: number
+  metadata?: TMetadata
+}
+
 export type TokenConstructorDataFor<
   TChainId extends ChainId,
   TMetadata extends CurrencyMetadata = CurrencyMetadata,
-> = TChainId extends EvmChainId
-  ? EvmTokenConstructorData<TMetadata>
-  : TChainId extends MvmChainId
-    ? MvmTokenConstructorData<TMetadata>
-    : TChainId extends SvmChainId
-      ? SvmTokenConstructorData<TMetadata>
-      : TChainId extends StellarChainId
-        ? StellarTokenConstructorData<TMetadata>
-        : never
+> =
+  | GenericTokenConstructorData<TChainId, TMetadata>
+  | (TChainId extends EvmChainId
+      ? EvmTokenConstructorData<TMetadata>
+      : TChainId extends MvmChainId
+        ? MvmTokenConstructorData<TMetadata>
+        : TChainId extends SvmChainId
+          ? SvmTokenConstructorData<TMetadata>
+          : TChainId extends StellarChainId
+            ? StellarTokenConstructorData<TMetadata>
+            : never)
 
 export function getNativeFor<
   TChainId extends NativeChainId,

--- a/src/generic/types/for-chain.test-d.ts
+++ b/src/generic/types/for-chain.test-d.ts
@@ -89,6 +89,18 @@ describe('generic/types/for-chain.ts types', () => {
       >()
     })
 
+    it('should be assignable to CurrencyFor for native chain families', () => {
+      expectTypeOf<NativeFor<EvmChainId, Metadata>>().toMatchTypeOf<
+        CurrencyFor<EvmChainId, Metadata>
+      >()
+      expectTypeOf<NativeFor<SvmChainId, Metadata>>().toMatchTypeOf<
+        CurrencyFor<SvmChainId, Metadata>
+      >()
+      expectTypeOf<NativeFor<NativeChainId, Metadata>>().toMatchTypeOf<
+        CurrencyFor<NativeChainId, Metadata>
+      >()
+    })
+
     it('should reject token-only chain families', () => {
       type NativeForMvm = NativeFor<
         // @ts-expect-error MVM is intentionally excluded from NativeChainId.


### PR DESCRIPTION
## Summary
- Allow getTokenFor to accept generic token inputs where address is AddressFor<TChainId>
- Preserve chain-specific token constructor data support
- Add type coverage for generic EVM/SVM token inputs and NativeFor-to-CurrencyFor assignability

## Verification
- pnpm typecheck
- pnpm vitest -c ./test/vitest.config.ts run src/generic/currency/for-chain.test.ts
- pnpm lint:dryrun