### PR TITLE
chore: add generic token input changeset

### DIFF
--- a/.changeset/short-hounds-shop.md
+++ b/.changeset/short-hounds-shop.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Allow generic token factory inputs to use addresses derived from their chain id.


### PR DESCRIPTION
## Summary
- Add a patch changeset for the generic token input type widening merged in #466

## Verification
- Changeset-only PR