### PR TITLE
fix: keep native currency types assignable

### DIFF
--- a/.changeset/short-hounds-shop.md
+++ b/.changeset/short-hounds-shop.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Allow generic token factory inputs to use addresses derived from their chain id and keep native currency factory return types assignable to generic currency types.

--- a/src/generic/types/for-chain.test-d.ts
+++ b/src/generic/types/for-chain.test-d.ts
@@ -101,6 +101,22 @@ describe('generic/types/for-chain.ts types', () => {
       >()
     })
 
+    it('should be assignable to CurrencyFor for a generic native chain id', () => {
+      // Regression guard: this only holds because CurrencyFor's branch order
+      // matches NativeFor's, letting TypeScript relate the two conditional
+      // types for an unresolved generic `T`. Concrete-type checks above pass
+      // regardless of order, so they don't cover this case. The constraint
+      // `A extends B` fails to compile if NativeFor<T> is not assignable to
+      // CurrencyFor<T>.
+      type AssertAssignable<_A extends B, B> = true
+      type _Guard<T extends NativeChainId> = AssertAssignable<
+        NativeFor<T, Metadata>,
+        CurrencyFor<T, Metadata>
+      >
+
+      expectTypeOf<_Guard<NativeChainId>>().toEqualTypeOf<true>()
+    })
+
     it('should reject token-only chain families', () => {
       type NativeForMvm = NativeFor<
         // @ts-expect-error MVM is intentionally excluded from NativeChainId.

--- a/src/generic/types/for-chain.ts
+++ b/src/generic/types/for-chain.ts
@@ -43,15 +43,19 @@ export type TokenFor<
         ? StellarToken<Metadata>
         : never
 
+// Branch order matches `NativeFor` (Evm, then Svm) so TypeScript can relate the
+// two conditional types and prove `NativeFor<T>` is assignable to
+// `CurrencyFor<T>` for a generic `T`. The chain families are disjoint, so the
+// order has no effect on the resolved type.
 export type CurrencyFor<
   TChainId extends ChainId,
   Metadata extends CurrencyMetadata = CurrencyMetadata,
 > = TChainId extends EvmChainId
   ? EvmCurrency<Metadata>
-  : TChainId extends MvmChainId
-    ? MvmToken<Metadata>
-    : TChainId extends SvmChainId
-      ? SvmCurrency<Metadata>
+  : TChainId extends SvmChainId
+    ? SvmCurrency<Metadata>
+    : TChainId extends MvmChainId
+      ? MvmToken<Metadata>
       : TChainId extends StellarChainId
         ? StellarCurrency<Metadata>
         : never


### PR DESCRIPTION
## Summary
- Reorder CurrencyFor conditional branches to match NativeFor for generic native chain ids
- Add a regression type test proving NativeFor<T> is assignable to CurrencyFor<T>
- Add a patch changeset for this type fix

## Verification
- pnpm typecheck
- pnpm vitest -c ./test/vitest.config.ts run src/generic/currency/for-chain.test.ts
- pnpm lint:dryrun