### PR TITLE
fix: keep token currency types assignable

### DIFF
--- a/.changeset/short-hounds-shop.md
+++ b/.changeset/short-hounds-shop.md
@@ -2,4 +2,4 @@
 'sushi': patch
 ---
 
-Allow generic token factory inputs to use addresses derived from their chain id and keep native currency factory return types assignable to generic currency types.
+Allow generic token factory inputs to use addresses derived from their chain id and keep generic token/native currency types assignable to generic currency types.

--- a/src/generic/types/for-chain.test-d.ts
+++ b/src/generic/types/for-chain.test-d.ts
@@ -15,6 +15,7 @@ import type { SvmNative } from '../../svm/currency/native.js'
 import type { SvmToken } from '../../svm/currency/token.js'
 import type { SvmChainId } from '../../svm/index.js'
 import type { SvmID } from '../../svm/types/id.js'
+import type { ChainId } from '../chain/chains.js'
 import type {
   CurrencyFor,
   IDFor,
@@ -72,6 +73,20 @@ describe('generic/types/for-chain.ts types', () => {
       expectTypeOf<
         CurrencyFor<EvmChainId | SvmChainId, Metadata>
       >().toEqualTypeOf<EvmCurrency<Metadata> | SvmCurrency<Metadata>>()
+    })
+
+    it('should accept TokenFor for a generic chain id', () => {
+      // Regression guard: holds only because TokenFor's branch order matches
+      // CurrencyFor's, letting TypeScript relate the two conditional types for
+      // an unresolved generic `T`. The constraint `A extends B` fails to
+      // compile if TokenFor<T> is not assignable to CurrencyFor<T>.
+      type AssertAssignable<_A extends B, B> = true
+      type _Guard<T extends ChainId> = AssertAssignable<
+        TokenFor<T, Metadata>,
+        CurrencyFor<T, Metadata>
+      >
+
+      expectTypeOf<_Guard<ChainId>>().toEqualTypeOf<true>()
     })
   })
 

--- a/src/generic/types/for-chain.ts
+++ b/src/generic/types/for-chain.ts
@@ -30,23 +30,24 @@ import type { SvmID } from '../../svm/types/id.js'
 import type { ChainId } from '../chain/chains.js'
 import type { CurrencyMetadata } from '../currency/currency.js'
 
+// Branch order (Evm, Svm, Mvm, Stellar) is kept identical across `TokenFor`,
+// `NativeFor` and `CurrencyFor` so TypeScript can relate the conditional types
+// branch-by-branch and prove `TokenFor<T>`/`NativeFor<T>` are assignable to
+// `CurrencyFor<T>` for a generic `T`. The chain families are disjoint, so the
+// order has no effect on the resolved type — only on relatability.
 export type TokenFor<
   TChainId extends ChainId,
   Metadata extends CurrencyMetadata = CurrencyMetadata,
 > = TChainId extends EvmChainId
   ? EvmToken<Metadata>
-  : TChainId extends MvmChainId
-    ? MvmToken<Metadata>
-    : TChainId extends SvmChainId
-      ? SvmToken<Metadata>
+  : TChainId extends SvmChainId
+    ? SvmToken<Metadata>
+    : TChainId extends MvmChainId
+      ? MvmToken<Metadata>
       : TChainId extends StellarChainId
         ? StellarToken<Metadata>
         : never
 
-// Branch order matches `NativeFor` (Evm, then Svm) so TypeScript can relate the
-// two conditional types and prove `NativeFor<T>` is assignable to
-// `CurrencyFor<T>` for a generic `T`. The chain families are disjoint, so the
-// order has no effect on the resolved type.
 export type CurrencyFor<
   TChainId extends ChainId,
   Metadata extends CurrencyMetadata = CurrencyMetadata,


### PR DESCRIPTION
## Summary
- Reorder TokenFor conditional branches to match CurrencyFor for generic chain ids
- Add a regression type test proving TokenFor<T> is assignable to CurrencyFor<T>
- Update the pending changeset text to cover token and native generic currency assignability

## Verification
- pnpm typecheck
- pnpm vitest -c ./test/vitest.config.ts run src/generic/currency/for-chain.test.ts
- pnpm lint:dryrun