### PR TITLE
feat: move Stellar issuer into metadata

### DIFF
--- a/.changeset/stellar-issuer-metadata.md
+++ b/.changeset/stellar-issuer-metadata.md
@@ -1,0 +1,5 @@
+---
+'sushi': minor
+---
+
+Move Stellar token issuer data into token metadata. `StellarToken` and `SerializedStellarToken` no longer expose a top-level `issuer` field; use nullable `metadata.issuer` instead.

--- a/src/generic/currency/for-chain.test-d.ts
+++ b/src/generic/currency/for-chain.test-d.ts
@@ -8,7 +8,10 @@ import type {
 } from '../../evm/currency/token.js'
 import { MvmChainId } from '../../mvm/chain/chains.js'
 import type { MvmAddress, MvmToken } from '../../mvm/currency/token.js'
-import type { StellarContractAddress } from '../../stellar/address.js'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from '../../stellar/address.js'
 import { StellarChainId } from '../../stellar/chain/chains.js'
 import type { StellarToken } from '../../stellar/currency/token.js'
 import { SvmChainId } from '../../svm/chain/chains.js'
@@ -121,18 +124,26 @@ describe('generic/currency/for-chain.ts types', () => {
       expectTypeOf(data.metadata).toMatchTypeOf<Metadata>()
     })
 
-    it('matches Stellar token constructor data including issuer and origin', () => {
+    it('matches Stellar token constructor data including metadata issuer and origin', () => {
+      type StellarMetadata = {
+        issuer: StellarAccountAddress | null
+      }
+
       const data = {
         address: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA',
-        issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
         symbol: 'XLM',
         name: 'XLM',
         decimals: 7,
         origin: 'stellar.org',
-      } satisfies TokenConstructorDataFor<StellarChainId>
+        metadata: {
+          issuer:
+            'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV' as StellarAccountAddress,
+        },
+      } satisfies TokenConstructorDataFor<StellarChainId, StellarMetadata>
 
       expectTypeOf(data.address).toMatchTypeOf<StellarContractAddress>()
       expectTypeOf(data.origin).toMatchTypeOf<string>()
+      expectTypeOf(data.metadata).toMatchTypeOf<StellarMetadata>()
     })
 
     it('accepts chainId for compatibility', () => {
@@ -240,7 +251,16 @@ describe('generic/currency/for-chain.ts types', () => {
         symbol: 'APT',
         name: 'Aptos Coin',
         decimals: 8,
-        // @ts-expect-error issuer is Stellar-specific token data.
+        // @ts-expect-error issuer is not generic token constructor data.
+        issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
+      })
+
+      getTokenFor(StellarChainId.STELLAR, {
+        address: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA',
+        symbol: 'XLM',
+        name: 'XLM',
+        decimals: 7,
+        // @ts-expect-error issuer belongs in metadata.
         issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
       })
     })

--- a/src/generic/currency/for-chain.test.ts
+++ b/src/generic/currency/for-chain.test.ts
@@ -90,19 +90,23 @@ describe('generic/currency/for-chain.ts', () => {
     })
 
     it('creates Stellar tokens from constructor data', () => {
+      type Metadata = { issuer: null }
+      const metadata: Metadata = { issuer: null }
+
       const token = getTokenFor(StellarChainId.STELLAR, {
         address: 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA',
-        issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
         symbol: 'XLM',
         name: 'XLM',
         decimals: 7,
         origin: 'stellar.org',
+        metadata,
       })
 
       expect(token).toBeInstanceOf(StellarToken)
       expect(token.chainId).toBe(StellarChainId.STELLAR)
       expect(token.origin).toBe('stellar.org')
-      expectTypeOf(token).toEqualTypeOf<StellarToken<Record<string, unknown>>>()
+      expect(token.metadata.issuer).toBe(null)
+      expectTypeOf(token).toEqualTypeOf<StellarToken<Metadata>>()
     })
   })
 })

--- a/src/stellar/config/tokens/tokens/CETES.ts
+++ b/src/stellar/config/tokens/tokens/CETES.ts
@@ -10,12 +10,12 @@ export const STELLAR_CETES: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_CETES_ADDRESS[StellarChainId.STELLAR],
-    issuer: 'GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC',
     decimals: 7,
     symbol: 'CETES',
     name: 'CETES',
     origin: 'etherfuse.com',
     metadata: {
+      issuer: 'GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC',
       icon: 'https://assets.coingecko.com/coins/images/37855/standard/cetes.png',
     },
   }),

--- a/src/stellar/config/tokens/tokens/EURC.ts
+++ b/src/stellar/config/tokens/tokens/EURC.ts
@@ -10,12 +10,12 @@ export const STELLAR_EURC: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_EURC_ADDRESS[StellarChainId.STELLAR],
-    issuer: 'GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP2',
     decimals: 7,
     symbol: 'EURC',
     name: 'EURC',
     origin: 'circle.com',
     metadata: {
+      issuer: 'GDHU6WRG4IEQXM5NZ4BMPKOXHW76MZM4Y2IEMFDVXBSDP6SJY4ITNPP2',
       icon: 'https://stellar.myfilebase.com/ipfs/QmeRk7LG85cozSNey9QGARgbxYi1cG1dA1G6SNJGMTMdF2',
     },
   }),

--- a/src/stellar/config/tokens/tokens/PYUSD.ts
+++ b/src/stellar/config/tokens/tokens/PYUSD.ts
@@ -10,12 +10,12 @@ export const STELLAR_PYUSD: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_PYUSD_ADDRESS[StellarChainId.STELLAR],
-    issuer: 'GDQE7IXJ4HUHV6RQHIUPRJSEZE4DRS5WY577O2FY6YQ5LVWZ7JZTU2V5',
     decimals: 7,
     symbol: 'PYUSD',
     name: 'PYUSD',
     origin: 'paxos.com',
     metadata: {
+      issuer: 'GDQE7IXJ4HUHV6RQHIUPRJSEZE4DRS5WY577O2FY6YQ5LVWZ7JZTU2V5',
       icon: 'https://assets.coingecko.com/coins/images/31212/standard/PYUSD_Token_Logo_2x.png',
     },
   }),

--- a/src/stellar/config/tokens/tokens/SolvBTC.ts
+++ b/src/stellar/config/tokens/tokens/SolvBTC.ts
@@ -10,12 +10,12 @@ export const STELLAR_SOLVBTC: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_SOLVBTC_ADDRESS[StellarChainId.STELLAR],
-    issuer: undefined,
     decimals: 8,
     symbol: 'SolvBTC',
     name: 'Solv BTC',
     origin: 'solv.finance',
     metadata: {
+      issuer: null,
       icon: 'https://raw.githubusercontent.com/solv-finance/solv-resources/main/SolvBTC/SolvBTC.svg',
     },
   }),

--- a/src/stellar/config/tokens/tokens/USDC.ts
+++ b/src/stellar/config/tokens/tokens/USDC.ts
@@ -10,12 +10,12 @@ export const STELLAR_USDC: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_USDC_ADDRESS[StellarChainId.STELLAR],
-    issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
     decimals: 7,
     symbol: 'USDC',
     name: 'USDC',
     origin: 'centre.io',
     metadata: {
+      issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
       icon: 'https://stellar.myfilebase.com/ipfs/QmNcfZxs8e9uVyhEa3xoPWCsj3ZogGirtixMEC9Km4Fjm2',
     },
   }),

--- a/src/stellar/config/tokens/tokens/USDY.ts
+++ b/src/stellar/config/tokens/tokens/USDY.ts
@@ -10,12 +10,12 @@ export const STELLAR_USDY: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_USDY_ADDRESS[StellarChainId.STELLAR],
-    issuer: 'GAJMPX5NBOG6TQFPQGRABJEEB2YE7RFRLUKJDZAZGAD5GFX4J7TADAZ6',
     decimals: 7,
     symbol: 'USDY',
     name: 'USDY',
     origin: 'ondo.finance',
     metadata: {
+      issuer: 'GAJMPX5NBOG6TQFPQGRABJEEB2YE7RFRLUKJDZAZGAD5GFX4J7TADAZ6',
       icon: 'https://assets.coingecko.com/coins/images/31700/standard/usdy_(1).png',
     },
   }),

--- a/src/stellar/config/tokens/tokens/USTRY.ts
+++ b/src/stellar/config/tokens/tokens/USTRY.ts
@@ -10,12 +10,12 @@ export const STELLAR_USTRY: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_USTRY_ADDRESS[StellarChainId.STELLAR],
-    issuer: 'GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC',
     decimals: 7,
     symbol: 'USTRY',
     name: 'USTRY',
     origin: 'etherfuse.com',
     metadata: {
+      issuer: 'GCRYUGD5NVARGXT56XEZI5CIFCQETYHAPQQTHO2O3IQZTHDH4LATMYWC',
       icon: 'https://assets.coingecko.com/coins/images/52361/standard/-STABLEBOND-06.jpg',
     },
   }),

--- a/src/stellar/config/tokens/tokens/XLM.ts
+++ b/src/stellar/config/tokens/tokens/XLM.ts
@@ -10,12 +10,12 @@ export const STELLAR_XLM: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_XLM_ADDRESS[StellarChainId.STELLAR],
-    issuer: 'GDMTVHLWJTHSUDMZVVMXXH6VJHA2ZV3HNG5LYNAZ6RTWB7GISM6PGTUV',
     decimals: 7,
     symbol: 'XLM',
     name: 'XLM',
     origin: 'stellar.org',
     metadata: {
+      issuer: null,
       icon: 'https://assets.coingecko.com/coins/images/100/large/Stellar_symbol_black_RGB.png',
     },
   }),

--- a/src/stellar/config/tokens/tokens/xSolvBTC.ts
+++ b/src/stellar/config/tokens/tokens/xSolvBTC.ts
@@ -10,12 +10,12 @@ export const STELLAR_XSOLVBTC: Record<StellarChainId, StellarToken> = {
   [StellarChainId.STELLAR]: new StellarToken({
     chainId: StellarChainId.STELLAR,
     address: STELLAR_XSOLVBTC_ADDRESS[StellarChainId.STELLAR],
-    issuer: undefined,
     decimals: 8,
     symbol: 'xSolvBTC',
     name: 'xSolvBTC',
     origin: 'solv.finance',
     metadata: {
+      issuer: null,
       icon: 'https://raw.githubusercontent.com/solv-finance/solv-resources/main/xSolvBTC/xSolvBTC.svg',
     },
   }),

--- a/src/stellar/currency/token.test.ts
+++ b/src/stellar/currency/token.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { StellarChainId } from '../chain/chains.js'
+import { StellarToken } from './token.js'
+
+describe('StellarToken', () => {
+  it('serializes issuer through metadata only', () => {
+    const token = new StellarToken({
+      chainId: StellarChainId.STELLAR,
+      address: 'CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75',
+      symbol: 'USDC',
+      name: 'USDC',
+      decimals: 7,
+      metadata: {
+        issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      },
+    })
+
+    const json = token.toJSON()
+
+    expect(json).not.toHaveProperty('issuer')
+    expect(json.metadata.issuer).toBe(
+      'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+    )
+  })
+})

--- a/src/stellar/currency/token.ts
+++ b/src/stellar/currency/token.ts
@@ -2,9 +2,7 @@ import * as z from 'zod'
 import type { CurrencyMetadata } from '../../generic/currency/currency.js'
 import { Token } from '../../generic/currency/token.js'
 import {
-  isStellarAccountAddress,
   isStellarContractAddress,
-  type StellarAccountAddress,
   type StellarContractAddress,
 } from '../address.js'
 import { isStellarChainId, type StellarChainId } from '../chain/chains.js'
@@ -14,21 +12,17 @@ export class StellarToken<
   TMetadata extends CurrencyMetadata = Record<string, unknown>,
 > extends Token<StellarChainId, StellarContractAddress, TMetadata> {
   public readonly origin: string | undefined
-  public readonly issuer: StellarAccountAddress | undefined
 
   constructor({
-    issuer,
     origin,
     address,
     ...rest
   }: {
-    issuer?: StellarAccountAddress | undefined
     origin?: string
   } & ConstructorParameters<
     typeof Token<StellarChainId, StellarContractAddress, TMetadata>
   >[0]) {
     super({ address: normalizeStellarAddress(address), ...rest })
-    this.issuer = issuer ? normalizeStellarAddress(issuer) : issuer
     this.origin = origin
   }
 
@@ -40,7 +34,6 @@ export class StellarToken<
     return {
       chainId: this.chainId,
       address: this.address,
-      issuer: this.issuer,
       symbol: this.symbol,
       name: this.name,
       decimals: this.decimals,
@@ -76,11 +69,6 @@ export const serializedStellarTokenSchema = <
       .string()
       .refine(isStellarContractAddress)
       .transform((address) => address as StellarContractAddress),
-    issuer: z
-      .string()
-      .refine(isStellarAccountAddress)
-      .transform((address) => address as StellarAccountAddress)
-      .optional(),
     symbol: z.string(),
     name: z.string(),
     decimals: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary
- remove the top-level StellarToken issuer field and serialized schema entry
- store Stellar issuer values under existing free-form metadata, using null for issuerless tokens like XLM
- add runtime/type coverage and a minor changeset

## Verification
- pnpm exec vitest run -c ./test/vitest.config.ts src/stellar/currency/token.test.ts src/generic/currency/for-chain.test.ts
- pnpm typecheck
- pnpm build
- pnpm lint:dryrun

Note: commands emitted the existing Node engine warning because this shell runs Node 20.19.5 while the repo declares Node 22.x.