### PR TITLE
fix: more formatNumber

### DIFF
--- a/.changeset/stupid-trees-mix.md
+++ b/.changeset/stupid-trees-mix.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+formatNumber fixes

--- a/src/generic/format/number.test.ts
+++ b/src/generic/format/number.test.ts
@@ -127,7 +127,7 @@ describe('numberToFixed', () => {
   })
 
   describe('edge cases', () => {
-    it('should handle empty and z8ero values', () => {
+    it('should handle empty and zero values', () => {
       expect(numberToFixed(0, { maxFixed: 2 })).toBe('0')
       expect(numberToFixed('0', { maxFixed: 2 })).toBe('0')
       expect(numberToFixed('0.00', { maxFixed: 2 })).toBe('0')
@@ -141,6 +141,101 @@ describe('numberToFixed', () => {
     it('should handle scientific notation in strings', () => {
       expect(numberToFixed('1.23e-4', { maxFixed: 8 })).toBe('0.000123')
       expect(numberToFixed('1.23e+2', { maxFixed: 2 })).toBe('123')
+    })
+  })
+
+  describe('string rounding edge cases', () => {
+    it('should round fixed-decimal string inputs that overflow into a new integer digit', () => {
+      expect(numberToFixed('9.995', { fixed: 2 })).toBe('10')
+      expect(numberToFixed('-9.995', { fixed: 2 })).toBe('-10')
+    })
+
+    it('should round long leading-zero decimals when using significant digits', () => {
+      expect(numberToFixed('0.00009999', { significant: 2 })).toBe('0.0001')
+      expect(numberToFixed('-0.00009999', { significant: 2 })).toBe('-0.0001')
+    })
+
+    it('should round large negative strings when all significant digits are 9s', () => {
+      expect(numberToFixed('-9999.9', { significant: 1 })).toBe('-10000')
+    })
+  })
+
+  describe('fixed rounding cascades', () => {
+    it('should cascade rounding across multiple integer digits for strings', () => {
+      expect(numberToFixed('199.995', { fixed: 2 })).toBe('200')
+      expect(numberToFixed('-199.995', { fixed: 2 })).toBe('-200')
+    })
+
+    it('should keep trailing zeros for numeric inputs when the same rounding occurs', () => {
+      expect(numberToFixed(199.995, { fixed: 2 })).toBe('200.00')
+      expect(numberToFixed(-199.995, { fixed: 2 })).toBe('-200.00')
+    })
+
+    it('should handle +/-0.005 thresholds symmetrically', () => {
+      expect(numberToFixed('0.005', { fixed: 2 })).toBe('0.01')
+      expect(numberToFixed('-0.005', { fixed: 2 })).toBe('-0.01')
+      expect(numberToFixed(0.005, { fixed: 2 })).toBe('0.01')
+      expect(numberToFixed(-0.005, { fixed: 2 })).toBe('-0.01')
+    })
+
+    it('should preserve decimal accuracy for strings at IEEE rounding pain points', () => {
+      expect(numberToFixed('2.675', { fixed: 2 })).toBe('2.68')
+      expect(numberToFixed(2.675, { fixed: 2 })).toBe('2.67')
+    })
+  })
+
+  describe('maxFixed nuances', () => {
+    it('should truncate (not round) string inputs for maxFixed', () => {
+      expect(numberToFixed('2.999', { maxFixed: 2 })).toBe('2.99')
+      expect(numberToFixed('-2.999', { maxFixed: 2 })).toBe('-2.99')
+    })
+
+    it('should round numeric inputs for maxFixed after trimming trailing zeros', () => {
+      expect(numberToFixed(2.999, { maxFixed: 2 })).toBe('3')
+      expect(numberToFixed(-2.999, { maxFixed: 2 })).toBe('-3')
+    })
+
+    it('should drop redundant zeros for very small fractions supplied as strings', () => {
+      expect(numberToFixed('0.0001000', { maxFixed: 6 })).toBe('0.0001')
+      expect(numberToFixed('-0.0001000', { maxFixed: 6 })).toBe('-0.0001')
+    })
+
+    it('should distinguish between truncation and rounding when maxFixed is zero', () => {
+      expect(numberToFixed('12.9', { maxFixed: 0 })).toBe('12')
+      expect(numberToFixed('-12.9', { maxFixed: 0 })).toBe('-12')
+      expect(numberToFixed(12.9, { maxFixed: 0 })).toBe('13')
+      expect(numberToFixed(-12.9, { maxFixed: 0 })).toBe('-13')
+    })
+
+    it('should trim or round repeating decimals based on input type', () => {
+      expect(numberToFixed('0.10999', { maxFixed: 3 })).toBe('0.109')
+      expect(numberToFixed('-0.10999', { maxFixed: 3 })).toBe('-0.109')
+      expect(numberToFixed(0.10999, { maxFixed: 3 })).toBe('0.11')
+      expect(numberToFixed(-0.10999, { maxFixed: 3 })).toBe('-0.11')
+    })
+  })
+
+  describe('significant digits with decimals', () => {
+    it('should keep track of leading zeros for negative decimals', () => {
+      expect(numberToFixed('-0.00056789', { significant: 2 })).toBe('-0.0006')
+    })
+
+    it('should round decimals just below one down to -1 with a single significant digit', () => {
+      expect(numberToFixed('-0.9994', { significant: 1 })).toBe('-1')
+    })
+  })
+
+  describe('input validation', () => {
+    it('should reject invalid numeric strings', () => {
+      expect(() => numberToFixed('invalid', { fixed: 2 })).toThrow(
+        'Invalid number string',
+      )
+    })
+
+    it('should reject empty option objects', () => {
+      expect(() => numberToFixed(1, {} as any)).toThrow(
+        'Invalid arguments for numberToFixed',
+      )
     })
   })
 })

--- a/src/generic/format/number.test.ts
+++ b/src/generic/format/number.test.ts
@@ -226,6 +226,11 @@ describe('numberToFixed', () => {
   })
 
   describe('input validation', () => {
+    it('should accept trailing decimal strings', () => {
+      expect(numberToFixed('1.', { fixed: 2 })).toBe('1.00')
+      expect(numberToFixed('1.', { significant: 2 })).toBe('1')
+    })
+
     it('should reject invalid numeric strings', () => {
       expect(() => numberToFixed('invalid', { fixed: 2 })).toThrow(
         'Invalid number string',

--- a/src/generic/format/number.ts
+++ b/src/generic/format/number.ts
@@ -175,7 +175,9 @@ function stringToFixed(
       significantDecimal = significantDecimal.slice(0, -1)
     }
 
-    const res = `${integerPart}${significantDecimal ? `.${significantDecimal}` : ''}`
+    const res = `${integerPart}${
+      significantDecimal ? `.${significantDecimal}` : ''
+    }`
     return roundString(str, res)
   }
 
@@ -192,6 +194,10 @@ function stringToFixed(
 }
 
 function roundString(original: string, formatted: string) {
+  if (!original.match(/^-?\d*\.?\d+$/)) {
+    throw new Error('Invalid number string')
+  }
+
   const decimalIndex = original.indexOf('.')
 
   const nextDigitIndex = formatted.length
@@ -216,15 +222,16 @@ function roundString(original: string, formatted: string) {
       // handle full carry (e.g., "9.9" -> "10")
       if (formatted.length === 0 || formatted === '-') {
         const negative = original.startsWith('-')
-        const zeros = Math.max(decimalIndex, 0)
+        const digitsLeftOfDecimal = decimalIndex - (negative ? 1 : 0)
+        const zeros = Math.max(digitsLeftOfDecimal, 0)
         return `${negative ? '-' : ''}1${'0'.repeat(zeros)}`
       }
     }
 
-    return `${formatted.substring(0, formatted.length - 1)}${String.fromCharCode(lastDigit() + 1)}`.padEnd(
-      decimalIndex,
-      '0',
-    )
+    return `${formatted.substring(
+      0,
+      formatted.length - 1,
+    )}${String.fromCharCode(lastDigit() + 1)}`.padEnd(decimalIndex, '0')
   }
 
   return formatted

--- a/src/generic/format/number.ts
+++ b/src/generic/format/number.ts
@@ -194,7 +194,7 @@ function stringToFixed(
 }
 
 function roundString(original: string, formatted: string) {
-  if (!original.match(/^-?\d*\.?\d+$/)) {
+  if (!original.match(/^-?(?:\d+\.?|\d*\.\d+)$/)) {
     throw new Error('Invalid number string')
   }
 


### PR DESCRIPTION
Extracted from #378 (without the dRPC URL change).

Fixes `numberToFixed`/`stringToFixed` rounding for strings, notably the negative full-carry case (e.g. `-9.995` with `{ fixed: 2 }` returned `-100`, now `-10`; `-9999.9` with `{ significant: 1 }` returned `-100000`, now `-10000`). Also adds an invalid-number-string guard in `roundString` and broad test coverage for string-vs-numeric rounding edge cases.