### PR TITLE
fix: preserve svm address brand in ids

### DIFF
--- a/.changeset/early-parrots-search.md
+++ b/.changeset/early-parrots-search.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+Return chain contract address types from getNativeAddress.

--- a/.changeset/green-owls-join.md
+++ b/.changeset/green-owls-join.md
@@ -1,0 +1,5 @@
+---
+"sushi": patch
+---
+
+Preserve branded SVM address types when parsing token IDs.

--- a/src/generic/types/for-chain.ts
+++ b/src/generic/types/for-chain.ts
@@ -13,7 +13,11 @@ import type {
   MvmToken,
   MvmTxHash,
 } from '../../mvm/currency/token.js'
-import type { StellarAddress, StellarTxHash } from '../../stellar/address.js'
+import type {
+  StellarAddress,
+  StellarContractAddress,
+  StellarTxHash,
+} from '../../stellar/address.js'
 import type { StellarChainId } from '../../stellar/chain/chains.js'
 import type { StellarCurrency } from '../../stellar/currency/currency.js'
 import type { StellarToken } from '../../stellar/currency/token.js'
@@ -81,6 +85,17 @@ export type AddressFor<TChainId extends ChainId> = TChainId extends EvmChainId
       : TChainId extends StellarChainId
         ? StellarAddress
         : never
+
+export type ContractAddressFor<TChainId extends ChainId> =
+  TChainId extends EvmChainId
+    ? EvmAddress
+    : TChainId extends MvmChainId
+      ? MvmAddress
+      : TChainId extends SvmChainId
+        ? SvmAddress
+        : TChainId extends StellarChainId
+          ? StellarContractAddress
+          : never
 
 export type TxHashFor<TChainId extends ChainId> = TChainId extends EvmChainId
   ? EvmTxHash

--- a/src/generic/utils/id.test-d.ts
+++ b/src/generic/utils/id.test-d.ts
@@ -1,0 +1,35 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { SvmChainId } from '~/svm/chain/chains.js'
+import type { SvmAddress } from '~/svm/currency/token.js'
+import type { EvmChainId } from '../../evm/chain/chains.js'
+import type { EvmAddress } from '../../evm/currency/token.js'
+import type { ID } from '../types/id.js'
+import { getChainIdAddressFromId, getIdFromChainIdAddress } from './id.js'
+
+describe('getChainIdAddressFromId', () => {
+  it('preserves EVM chainId and address types', () => {
+    const id = '1:0xaa' as ID<EvmChainId, EvmAddress>
+
+    expectTypeOf(getChainIdAddressFromId(id)).toEqualTypeOf<{
+      chainId: EvmChainId
+      address: EvmAddress
+    }>()
+  })
+
+  it('preserves Solana chainId and address types', () => {
+    const id = getIdFromChainIdAddress(
+      SvmChainId.SOLANA,
+      'So11111111111111111111111111111111111111112' as SvmAddress,
+    )
+
+    expectTypeOf(getChainIdAddressFromId(id)).not.toEqualTypeOf<{
+      chainId: SvmChainId
+      address: `${SvmAddress}`
+    }>()
+
+    expectTypeOf(getChainIdAddressFromId(id)).toEqualTypeOf<{
+      chainId: SvmChainId
+      address: SvmAddress
+    }>()
+  })
+})

--- a/src/generic/utils/id.ts
+++ b/src/generic/utils/id.ts
@@ -1,8 +1,14 @@
+import type { SvmAddress } from '~/svm/currency/token.js'
 import type { ChainId } from '../chain/chains.js'
 import type { AddressFor } from '../types/for-chain.js'
 import type { ID } from '../types/id.js'
 import { getNativeAddress } from './native-address.js'
 import { normalizeAddress } from './normalize-address.js'
+
+// Hacky fix, SvmAddress is a branded type, but when used in a template literal type, it loses its branding.
+type ReturnedAddress<TAddress extends string> = TAddress extends `${SvmAddress}`
+  ? SvmAddress
+  : TAddress
 
 export function getChainIdAddressFromId<
   TChainId extends ChainId,
@@ -11,7 +17,7 @@ export function getChainIdAddressFromId<
   id: ID<TChainId, TAddress>,
 ): {
   chainId: TChainId
-  address: TAddress
+  address: ReturnedAddress<TAddress>
 } {
   const separatorIndex = id.indexOf(':')
 
@@ -22,7 +28,7 @@ export function getChainIdAddressFromId<
   }
 
   const chainId = +id.slice(0, separatorIndex) as TChainId
-  const address = id.slice(separatorIndex + 1) as TAddress
+  const address = id.slice(separatorIndex + 1) as ReturnedAddress<TAddress>
 
   if (!chainId || !address) {
     throw new Error(

--- a/src/generic/utils/id.ts
+++ b/src/generic/utils/id.ts
@@ -1,4 +1,4 @@
-import type { SvmAddress } from '~/svm/currency/token.js'
+import type { SvmAddress } from '../../svm/currency/token.js'
 import type { ChainId } from '../chain/chains.js'
 import type { AddressFor } from '../types/for-chain.js'
 import type { ID } from '../types/id.js'

--- a/src/generic/utils/native-address.test-d.ts
+++ b/src/generic/utils/native-address.test-d.ts
@@ -1,0 +1,25 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { EvmChainId } from '../../evm/chain/chains.js'
+import type { EvmAddress } from '../../evm/currency/token.js'
+import type {
+  StellarAccountAddress,
+  StellarContractAddress,
+} from '../../stellar/address.js'
+import { StellarChainId } from '../../stellar/chain/chains.js'
+import { getNativeAddress } from './native-address.js'
+
+describe('getNativeAddress', () => {
+  it('returns contract address types', () => {
+    expectTypeOf(
+      getNativeAddress(EvmChainId.ETHEREUM),
+    ).toEqualTypeOf<EvmAddress>()
+
+    expectTypeOf(
+      getNativeAddress(StellarChainId.STELLAR),
+    ).toEqualTypeOf<StellarContractAddress>()
+
+    expectTypeOf(
+      getNativeAddress(StellarChainId.STELLAR),
+    ).not.toEqualTypeOf<StellarAccountAddress>()
+  })
+})

--- a/src/generic/utils/native-address.ts
+++ b/src/generic/utils/native-address.ts
@@ -7,26 +7,26 @@ import { stellarNativeAddress } from '../../stellar/config/simple-constants.js'
 import { isSvmChainId } from '../../svm/chain/chains.js'
 import { svmNativeAddress } from '../../svm/config/simple-constants.js'
 import type { ChainId } from '../chain/chains.js'
-import type { AddressFor } from '../types/for-chain.js'
+import type { ContractAddressFor } from '../types/for-chain.js'
 import { assertNever } from './assert-never.js'
 
 export function getNativeAddress<TChainId extends ChainId>(
   chainId: TChainId,
-): AddressFor<TChainId> {
+): ContractAddressFor<TChainId> {
   if (isEvmChainId(chainId)) {
-    return evmNativeAddress as AddressFor<TChainId>
+    return evmNativeAddress as ContractAddressFor<TChainId>
   }
 
   if (isMvmChainId(chainId)) {
-    return mvmNativeAddress as AddressFor<TChainId>
+    return mvmNativeAddress as ContractAddressFor<TChainId>
   }
 
   if (isSvmChainId(chainId)) {
-    return svmNativeAddress as AddressFor<TChainId>
+    return svmNativeAddress as ContractAddressFor<TChainId>
   }
 
   if (isStellarChainId(chainId)) {
-    return stellarNativeAddress as AddressFor<TChainId>
+    return stellarNativeAddress as ContractAddressFor<TChainId>
   }
 
   assertNever(chainId, `getNativeAddress, unsupported chainId: ${chainId}`)

--- a/src/stellar/config/simple-constants.ts
+++ b/src/stellar/config/simple-constants.ts
@@ -1,11 +1,8 @@
-import type {
-  StellarAccountAddress,
-  StellarContractAddress,
-} from '../address.js'
+import type { StellarContractAddress } from '../address.js'
 import { StellarChainId } from '../chain/chains.js'
 
 export const stellarNativeAddress =
-  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as const satisfies StellarAccountAddress
+  'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as const satisfies StellarContractAddress
 
 export const SUSHISWAP_V3_FACTORY_ADDRESS: Record<
   StellarChainId,


### PR DESCRIPTION
## Summary
- preserve branded SVM address types when parsing IDs
- add a type-level regression test
- add a patch changeset for sushi

## Test
- pnpm typecheck