### PR TITLE
feat: add human-readable prices and exact formatting

### DIFF
--- a/.changeset/human-price-constructors.md
+++ b/.changeset/human-price-constructors.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Add human-readable `Price.fromHuman` and `Price.tryFromHuman` constructors.

--- a/.changeset/human-price-constructors.md
+++ b/.changeset/human-price-constructors.md
@@ -2,4 +2,5 @@
 'sushi': patch
 ---
 
-Add human-readable `Price.fromHuman` and `Price.tryFromHuman` constructors.
+Add human-readable `Price.fromHuman` and `Price.tryFromHuman` constructors and
+format `Fraction` and `Price` values without floating-point precision loss.

--- a/site/pages/sdk/concepts/primitives.mdx
+++ b/site/pages/sdk/concepts/primitives.mdx
@@ -110,4 +110,4 @@ doubled.toSignificant(4)
 
 ## Precision notes
 
-`Amount`, `Price`, and `Fraction` keep core math in bigint-backed values. Methods such as `toNumber`, `toString`, and `toSignificant` are for display and can lose precision for very large values.
+`Amount`, `Price`, and `Fraction` keep core math in bigint-backed values. `toString` and `toSignificant` format directly from those bigint-backed values, applying the requested rounding or truncation without first converting to a JavaScript number. `toNumber` is for display and can lose precision for very large values.

--- a/site/pages/sdk/reference/sushi/math.mdx
+++ b/site/pages/sdk/reference/sushi/math.mdx
@@ -35,4 +35,4 @@ const slippage = new Percent({ numerator: 5n, denominator: 1000n })
 | `toJSON` | Serialize numerator/denominator. |
 | `asFraction` | Return a plain `Fraction` from subclasses. |
 
-BigInt math preserves integer precision. Methods such as `toNumber` and formatting convert to JavaScript number/string and should be used for display, not critical accounting.
+BigInt math preserves integer precision. `toString` and `toSignificant` format directly from the fraction's bigint values with the requested precision. `toNumber` converts to a JavaScript number and can lose precision, so it should be used for display rather than critical accounting.

--- a/src/generic/currency/price.test-d.ts
+++ b/src/generic/currency/price.test-d.ts
@@ -1,0 +1,59 @@
+import { it } from 'node:test'
+import { describe, expectTypeOf } from 'vitest'
+import { Price } from './price.js'
+import { Token } from './token.js'
+
+class BaseToken extends Token {
+  public override toJSON() {
+    return {} as any
+  }
+
+  public override wrap() {
+    return this
+  }
+}
+
+class QuoteToken extends Token {
+  public override toJSON() {
+    return {} as any
+  }
+
+  public override wrap() {
+    return this
+  }
+}
+
+const base = new BaseToken({
+  chainId: 1,
+  address: '0x1234567890abcdef1234567890abcdef12345678',
+  symbol: 'BASE',
+  name: 'Base',
+  decimals: 18,
+})
+
+const quote = new QuoteToken({
+  chainId: 1,
+  address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+  symbol: 'QUOTE',
+  name: 'Quote',
+  decimals: 6,
+})
+
+describe('generic/currency/price.ts types', () => {
+  it('preserves concrete base and quote currency types', () => {
+    const price = Price.fromHuman(base, quote, '1.25')
+
+    expectTypeOf(price).toEqualTypeOf<Price<BaseToken, QuoteToken>>()
+    expectTypeOf(price.base).toEqualTypeOf<BaseToken>()
+    expectTypeOf(price.quote).toEqualTypeOf<QuoteToken>()
+    expectTypeOf(price.invert()).toEqualTypeOf<Price<QuoteToken, BaseToken>>()
+  })
+
+  it('preserves types when trying to create a price', () => {
+    const price = Price.tryFromHuman(base, quote, '1.25')
+
+    expectTypeOf(price).toEqualTypeOf<
+      Price<BaseToken, QuoteToken> | undefined
+    >()
+  })
+})

--- a/src/generic/currency/price.test.ts
+++ b/src/generic/currency/price.test.ts
@@ -39,6 +39,7 @@ describe('Price', () => {
       expect(price.numerator).toBe(125000000n)
       expect(price.denominator).toBe(10000000000n)
       expect(price.invert().toNumber()).toBe(0.8)
+      expect(price.invert().toString({ maxFixed: 18 })).toBe('0.8')
     })
 
     it('accepts a decimal without a leading zero', () => {
@@ -83,6 +84,49 @@ describe('Price', () => {
       'Infinity',
     ])('returns undefined for invalid input %j', (value) => {
       expect(Price.tryFromHuman(wbtc, usdc, value)).toBeUndefined()
+    })
+  })
+
+  describe('string formatting', () => {
+    it('formats very small prices without scientific notation', () => {
+      const price = Price.fromHuman(wbtc, usdc, '0.000000000001')
+
+      expect(price.toString({ maxFixed: 18 })).toBe('0.000000000001')
+      expect(price.toString({ significant: 6 })).toBe('0.000000000001')
+    })
+
+    it('truncates repeating prices to maxFixed decimal places', () => {
+      const price = new Price({
+        base: wbtc,
+        quote: wbtc,
+        numerator: 1n,
+        denominator: 3n,
+      })
+
+      expect(price.toString({ maxFixed: 18 })).toBe('0.333333333333333333')
+    })
+
+    it('preserves prices beyond Number.MAX_SAFE_INTEGER', () => {
+      const price = new Price({
+        base: wbtc,
+        quote: wbtc,
+        numerator: 9007199254740993n,
+      })
+
+      expect(price.toString({ maxFixed: 18 })).toBe('9007199254740993')
+    })
+
+    it('supports fixed, maxFixed, and significant formatting', () => {
+      const price = new Price({
+        base: wbtc,
+        quote: wbtc,
+        numerator: 1n,
+        denominator: 8n,
+      })
+
+      expect(price.toString({ fixed: 3 })).toBe('0.125')
+      expect(price.toString({ maxFixed: 2 })).toBe('0.12')
+      expect(price.toString({ significant: 2 })).toBe('0.13')
     })
   })
 })

--- a/src/generic/currency/price.test.ts
+++ b/src/generic/currency/price.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { Price } from './price.js'
+import { Token } from './token.js'
+
+class TestToken extends Token {
+  public override toJSON() {
+    return {} as any
+  }
+
+  public override wrap() {
+    return this
+  }
+}
+
+const wbtc = new TestToken({
+  decimals: 8,
+  symbol: 'WBTC',
+  name: 'Wrapped Bitcoin',
+  chainId: 1,
+  address: '0x1234567890abcdef1234567890abcdef12345678',
+})
+
+const usdc = new TestToken({
+  decimals: 6,
+  symbol: 'USDC',
+  name: 'USD Coin',
+  chainId: 1,
+  address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+})
+
+describe('Price', () => {
+  describe('fromHuman', () => {
+    it('creates a price for currencies with different decimals', () => {
+      const price = Price.fromHuman(wbtc, usdc, '1.25')
+
+      expect(price.base).toBe(wbtc)
+      expect(price.quote).toBe(usdc)
+      expect(price.toNumber()).toBe(1.25)
+      expect(price.numerator).toBe(125000000n)
+      expect(price.denominator).toBe(10000000000n)
+      expect(price.invert().toNumber()).toBe(0.8)
+    })
+
+    it('accepts a decimal without a leading zero', () => {
+      expect(Price.fromHuman(wbtc, usdc, '.5').toNumber()).toBe(0.5)
+    })
+
+    it('accepts zero', () => {
+      const price = Price.fromHuman(wbtc, usdc, '0')
+
+      expect(price.toNumber()).toBe(0)
+      expect(price.numerator).toBe(0n)
+    })
+
+    it('preserves more than 18 fractional digits', () => {
+      const price = Price.fromHuman(wbtc, usdc, '0.0000000000000000001')
+
+      expect(price.numerator).toBe(1000000n)
+      expect(price.denominator).toBe(1000000000000000000000000000n)
+    })
+
+    it.each([
+      '',
+      '-1',
+      '1e6',
+      'Infinity',
+    ])('rejects invalid input %j', (value) => {
+      expect(() => Price.fromHuman(wbtc, usdc, value)).toThrow(
+        `Invalid price: ${value}`,
+      )
+    })
+  })
+
+  describe('tryFromHuman', () => {
+    it('returns a price for valid input', () => {
+      expect(Price.tryFromHuman(wbtc, usdc, '1.25')?.toNumber()).toBe(1.25)
+    })
+
+    it.each([
+      '',
+      '-1',
+      '1e6',
+      'Infinity',
+    ])('returns undefined for invalid input %j', (value) => {
+      expect(Price.tryFromHuman(wbtc, usdc, value)).toBeUndefined()
+    })
+  })
+})

--- a/src/generic/currency/price.ts
+++ b/src/generic/currency/price.ts
@@ -11,6 +11,45 @@ export class Price<
   public readonly base: TBase
   public readonly quote: TQuote
 
+  /**
+   * Creates a Price from a human-readable quote-per-base value, e.g. "1.5".
+   */
+  public static fromHuman<TBase extends Currency, TQuote extends Currency>(
+    base: TBase,
+    quote: TQuote,
+    value: string,
+  ): Price<TBase, TQuote> {
+    if (!value.match(/^\d*\.?\d+$/)) {
+      throw new Error(`Invalid price: ${value}`)
+    }
+
+    const [whole = '', fraction = ''] = value.split('.')
+    const decimalScale = 10n ** BigInt(fraction.length)
+    const valueWithoutDecimals = BigInt(`${whole}${fraction}`)
+
+    return new Price({
+      base,
+      quote,
+      numerator: valueWithoutDecimals * 10n ** BigInt(quote.decimals),
+      denominator: decimalScale * 10n ** BigInt(base.decimals),
+    })
+  }
+
+  /**
+   * Tries to create a Price from a human-readable quote-per-base value.
+   */
+  public static tryFromHuman<TBase extends Currency, TQuote extends Currency>(
+    base: TBase,
+    quote: TQuote,
+    value: string,
+  ): Price<TBase, TQuote> | undefined {
+    try {
+      return Price.fromHuman(base, quote, value)
+    } catch {
+      return undefined
+    }
+  }
+
   constructor(
     args:
       | {

--- a/src/generic/currency/price.ts
+++ b/src/generic/currency/price.ts
@@ -1,4 +1,3 @@
-import { numberToFixed } from '../format/number.js'
 import { Fraction } from '../math/fraction.js'
 import type { BigintIsh } from '../types/bigintish.js'
 import { Amount } from './amount.js'
@@ -104,8 +103,8 @@ export class Price<
     return super.mul(this.scalar).toNumber()
   }
 
-  public override toString(args: Parameters<typeof numberToFixed>[1]): string {
-    return numberToFixed(this.toNumber(), args)
+  public override toString(args: Parameters<Fraction['toString']>[0]): string {
+    return super.mul(this.scalar).toString(args)
   }
 
   public override toSignificant(significantDigits = 5): string {

--- a/src/generic/math/fraction.test.ts
+++ b/src/generic/math/fraction.test.ts
@@ -263,6 +263,26 @@ describe('Fraction', () => {
       expect(fraction.toString({ fixed: 2 })).toBe('-0.13')
       expect(fraction.toString({ maxFixed: 2 })).toBe('-0.12')
     })
+
+    it('formats zero-denominator fractions as non-finite numbers', () => {
+      const infinity = new Fraction({ numerator: 1n, denominator: 2n }).div(
+        new Fraction({ numerator: 0n }),
+      )
+
+      expect(infinity.toString({ fixed: 2 })).toBe('Infinity')
+      expect(infinity.toString({ maxFixed: 2 })).toBe('Infinity')
+      expect(infinity.toString({ significant: 2 })).toBe('Infinity')
+      expect(
+        new Fraction({ numerator: -1n, denominator: 0n }).toString({
+          maxFixed: 2,
+        }),
+      ).toBe('-Infinity')
+      expect(
+        new Fraction({ numerator: 0n, denominator: 0n }).toString({
+          maxFixed: 2,
+        }),
+      ).toBe('NaN')
+    })
   })
 
   describe('serialization', () => {

--- a/src/generic/math/fraction.test.ts
+++ b/src/generic/math/fraction.test.ts
@@ -188,6 +188,83 @@ describe('Fraction', () => {
     })
   })
 
+  describe('string formatting', () => {
+    it('formats terminating fractions without floating-point artifacts', () => {
+      const fraction = new Fraction({ numerator: 4n, denominator: 5n })
+
+      expect(fraction.toString({ maxFixed: 18 })).toBe('0.8')
+    })
+
+    it('truncates repeating fractions to maxFixed decimal places', () => {
+      const fraction = new Fraction({ numerator: 1n, denominator: 3n })
+
+      expect(fraction.toString({ maxFixed: 18 })).toBe('0.333333333333333333')
+    })
+
+    it('preserves very small fractions in ordinary decimal notation', () => {
+      const fraction = new Fraction({
+        numerator: 1n,
+        denominator: 10n ** 12n,
+      })
+
+      expect(fraction.toString({ maxFixed: 18 })).toBe('0.000000000001')
+      expect(fraction.toSignificant(6)).toBe('0.000000000001')
+    })
+
+    it('preserves integers beyond Number.MAX_SAFE_INTEGER', () => {
+      const fraction = new Fraction({
+        numerator: 9007199254740993n,
+        denominator: 1n,
+      })
+
+      expect(fraction.toString({ maxFixed: 18 })).toBe('9007199254740993')
+    })
+
+    it('rounds and pads fixed decimal places', () => {
+      expect(
+        new Fraction({ numerator: 1n, denominator: 8n }).toString({
+          fixed: 2,
+        }),
+      ).toBe('0.13')
+      expect(
+        new Fraction({ numerator: 1n, denominator: 2n }).toString({
+          fixed: 3,
+        }),
+      ).toBe('0.500')
+      expect(
+        new Fraction({ numerator: 199995n, denominator: 1000n }).toString({
+          fixed: 2,
+        }),
+      ).toBe('200.00')
+    })
+
+    it('rounds to significant digits without scientific notation', () => {
+      expect(
+        new Fraction({ numerator: 1n, denominator: 3n }).toString({
+          significant: 6,
+        }),
+      ).toBe('0.333333')
+      expect(
+        new Fraction({
+          numerator: 123456789123n,
+          denominator: 100n,
+        }).toString({ significant: 4 }),
+      ).toBe('1235000000')
+      expect(
+        new Fraction({ numerator: 9999n, denominator: 10n }).toString({
+          significant: 3,
+        }),
+      ).toBe('1000')
+    })
+
+    it('formats negative fractions', () => {
+      const fraction = new Fraction({ numerator: -1n, denominator: 8n })
+
+      expect(fraction.toString({ fixed: 2 })).toBe('-0.13')
+      expect(fraction.toString({ maxFixed: 2 })).toBe('-0.12')
+    })
+  })
+
   describe('serialization', () => {
     it('should serialize to JSON correctly', () => {
       const fraction = new Fraction({ numerator: 3, denominator: 4 })

--- a/src/generic/math/fraction.ts
+++ b/src/generic/math/fraction.ts
@@ -235,24 +235,33 @@ export class Fraction {
         Number.isSafeInteger(args.fixed) && args.fixed >= 0,
         'Fixed digits must be a non-negative safe integer',
       )
-      return this.formatDecimal(args.fixed, { round: true, trim: false })
-    }
-
-    if ('maxFixed' in args) {
+    } else if ('maxFixed' in args) {
       invariant(
         Number.isSafeInteger(args.maxFixed) && args.maxFixed >= 0,
         'Maximum fixed digits must be a non-negative safe integer',
       )
-      return this.formatDecimal(args.maxFixed, { round: false, trim: true })
-    }
-
-    if ('significant' in args) {
+    } else if ('significant' in args) {
       invariant(
         Number.isSafeInteger(args.significant) && args.significant > 0,
         'Significant digits must be a positive safe integer',
       )
-      invariant(this.denominator !== 0n, 'Cannot format a fraction by zero')
+    } else {
+      throw new Error('Invalid arguments for Fraction.toString')
+    }
 
+    if (this.denominator === 0n) {
+      return this.toNumber().toString()
+    }
+
+    if ('fixed' in args) {
+      return this.formatDecimal(args.fixed, { round: true, trim: false })
+    }
+
+    if ('maxFixed' in args) {
+      return this.formatDecimal(args.maxFixed, { round: false, trim: true })
+    }
+
+    if ('significant' in args) {
       if (this.numerator === 0n) return '0'
 
       const decimalPlaces = args.significant - this.getDecimalExponent() - 1

--- a/src/generic/math/fraction.ts
+++ b/src/generic/math/fraction.ts
@@ -1,5 +1,5 @@
 import invariant from 'tiny-invariant'
-import { numberToFixed } from '../format/number.js'
+import type { numberToFixed } from '../format/number.js'
 import type { BigintIsh } from '../types/bigintish.js'
 
 export class Fraction {
@@ -164,12 +164,106 @@ export class Fraction {
     return Number(this.numerator) / Number(this.denominator)
   }
 
+  private formatDecimal(
+    decimalPlaces: number,
+    { round, trim }: { round: boolean; trim: boolean },
+  ): string {
+    invariant(
+      Number.isSafeInteger(decimalPlaces),
+      'Decimal places must be a safe integer',
+    )
+    invariant(this.denominator !== 0n, 'Cannot format a fraction by zero')
+
+    const negative = this.numerator < 0n !== this.denominator < 0n
+    const numerator = this.numerator < 0n ? -this.numerator : this.numerator
+    const denominator =
+      this.denominator < 0n ? -this.denominator : this.denominator
+
+    const scale = 10n ** BigInt(Math.abs(decimalPlaces))
+    const scaledDenominator =
+      decimalPlaces >= 0 ? denominator : denominator * scale
+    const scaledNumerator = decimalPlaces >= 0 ? numerator * scale : numerator
+
+    let scaledValue = scaledNumerator / scaledDenominator
+    const remainder = scaledNumerator % scaledDenominator
+    if (round && remainder * 2n >= scaledDenominator) {
+      scaledValue += 1n
+    }
+
+    let integerPart: string
+    let decimalPart = ''
+    if (decimalPlaces > 0) {
+      const value = scaledValue.toString().padStart(decimalPlaces + 1, '0')
+      integerPart = value.slice(0, -decimalPlaces)
+      decimalPart = value.slice(-decimalPlaces)
+    } else {
+      integerPart = (scaledValue * scale).toString()
+    }
+
+    if (trim) {
+      decimalPart = decimalPart.replace(/0+$/, '')
+    }
+
+    return `${negative ? '-' : ''}${integerPart}${
+      decimalPart ? `.${decimalPart}` : ''
+    }`
+  }
+
+  private getDecimalExponent(): number {
+    const numerator = this.numerator < 0n ? -this.numerator : this.numerator
+    const denominator =
+      this.denominator < 0n ? -this.denominator : this.denominator
+
+    invariant(numerator !== 0n, 'Cannot get the decimal exponent of zero')
+    invariant(denominator !== 0n, 'Cannot format a fraction by zero')
+
+    let exponent = numerator.toString().length - denominator.toString().length
+
+    if (
+      (exponent >= 0 && numerator < denominator * 10n ** BigInt(exponent)) ||
+      (exponent < 0 && numerator * 10n ** BigInt(-exponent) < denominator)
+    ) {
+      exponent -= 1
+    }
+
+    return exponent
+  }
+
   public toString(args: Parameters<typeof numberToFixed>[1]): string {
-    return numberToFixed(this.toNumber(), args)
+    if ('fixed' in args) {
+      invariant(
+        Number.isSafeInteger(args.fixed) && args.fixed >= 0,
+        'Fixed digits must be a non-negative safe integer',
+      )
+      return this.formatDecimal(args.fixed, { round: true, trim: false })
+    }
+
+    if ('maxFixed' in args) {
+      invariant(
+        Number.isSafeInteger(args.maxFixed) && args.maxFixed >= 0,
+        'Maximum fixed digits must be a non-negative safe integer',
+      )
+      return this.formatDecimal(args.maxFixed, { round: false, trim: true })
+    }
+
+    if ('significant' in args) {
+      invariant(
+        Number.isSafeInteger(args.significant) && args.significant > 0,
+        'Significant digits must be a positive safe integer',
+      )
+      invariant(this.denominator !== 0n, 'Cannot format a fraction by zero')
+
+      if (this.numerator === 0n) return '0'
+
+      const decimalPlaces = args.significant - this.getDecimalExponent() - 1
+      return this.formatDecimal(decimalPlaces, { round: true, trim: true })
+    }
+
+    throw new Error('Invalid arguments for Fraction.toString')
   }
 
   public toSignificant(significantDigits: number): string {
-    return this.toNumber().toPrecision(significantDigits)
+    return this.toString({ significant: significantDigits })
   }
 
   public toJSON() {


### PR DESCRIPTION
## Summary

- add `Price.fromHuman` and `Price.tryFromHuman`
- parse positive decimal strings exactly with bigint scaling across differing currency decimals
- format `Fraction` and scaled `Price` values using exact bigint arithmetic instead of JavaScript numbers
- support predictable truncation for `maxFixed`, half-up rounding and padding for `fixed`, and ordinary decimal notation for `significant`
- cover terminating and repeating fractions, tiny and large values, inversion, differing decimals, invalid inputs, and concrete currency types
- add a patch changeset for `sushi`

## Testing

- `pnpm exec vitest -c ./test/vitest.config.ts run` (49 files; 501 passed, 2 skipped)
- `pnpm exec tsc --noEmit`
- `pnpm exec biome check src/generic/math/fraction.ts src/generic/math/fraction.test.ts src/generic/currency/price.ts src/generic/currency/price.test.ts src/generic/currency/price.test-d.ts`