### PR TITLE
fix: use real typescript for docs twoslash

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,10 +85,10 @@ importers:
         version: 5.32.6(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       viem:
         specifier: 'catalog:'
-        version: 2.55.0(@typescript/typescript6@6.0.2)(zod@4.4.3)
+        version: 2.55.0(typescript@6.0.3)(zod@4.4.3)
       vocs:
         specifier: 2.5.3
-        version: 2.5.3(@types/react@19.2.17)(@typescript/typescript6@6.0.2)(@vue/compiler-sfc@3.5.39)(axios@1.17.0)(esbuild@0.28.1)(mermaid@11.12.0)(react-dom@19.2.7(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.0.3)(rollup@4.52.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1))
+        version: 2.5.3(@types/react@19.2.17)(@vue/compiler-sfc@3.5.39)(axios@1.17.0)(esbuild@0.28.1)(mermaid@11.12.0)(react-dom@19.2.7(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.0.3)(rollup@4.52.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1))
       waku:
         specifier: 1.0.0-beta.6
         version: 1.0.0-beta.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
@@ -103,8 +103,8 @@ importers:
         specifier: 5.18.0
         version: 5.18.0
       typescript:
-        specifier: 'catalog:'
-        version: '@typescript/typescript6@6.0.2'
+        specifier: 6.0.3
+        version: 6.0.3
 
   src:
     dependencies:
@@ -6301,20 +6301,20 @@ snapshots:
 
   '@floating-ui/utils@0.2.12': {}
 
-  '@floating-ui/vue@1.1.11(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@floating-ui/vue@1.1.11(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@floating-ui/utils': 0.2.12
-      vue-demi: 0.14.10(vue@3.5.39(@typescript/typescript6@6.0.2))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@floating-ui/vue@1.1.9(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@floating-ui/vue@1.1.9(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@floating-ui/dom': 1.8.0
       '@floating-ui/utils': 0.2.10
-      vue-demi: 0.14.10(vue@3.5.39(@typescript/typescript6@6.0.2))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
@@ -6323,10 +6323,10 @@ snapshots:
     dependencies:
       tailwindcss: 4.3.2
 
-  '@headlessui/vue@1.7.23(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@headlessui/vue@1.7.23(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(@typescript/typescript6@6.0.2))
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
 
   '@hono/node-server@1.19.14(hono@4.12.29)':
     dependencies:
@@ -6851,36 +6851,36 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.52.4':
     optional: true
 
-  '@scalar/api-client@3.13.3(@typescript/typescript6@6.0.2)(axios@1.17.0)(tailwindcss@4.3.2)':
+  '@scalar/api-client@3.13.3(axios@1.17.0)(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.2)
-      '@headlessui/vue': 1.7.23(vue@3.5.39(@typescript/typescript6@6.0.2))
-      '@scalar/blocks': 0.1.4(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)
-      '@scalar/components': 0.27.6(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)
+      '@headlessui/vue': 1.7.23(vue@3.5.39(typescript@6.0.3))
+      '@scalar/blocks': 0.1.4(tailwindcss@4.3.2)(typescript@6.0.3)
+      '@scalar/components': 0.27.6(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
-      '@scalar/icons': 0.7.3(@typescript/typescript6@6.0.2)
-      '@scalar/oas-utils': 0.19.4(@typescript/typescript6@6.0.2)
+      '@scalar/icons': 0.7.3(typescript@6.0.3)
+      '@scalar/oas-utils': 0.19.4(typescript@6.0.3)
       '@scalar/openapi-types': 0.9.1
-      '@scalar/sidebar': 0.9.29(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)
+      '@scalar/sidebar': 0.9.29(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/snippetz': 0.9.21
       '@scalar/themes': 0.16.2
       '@scalar/typebox': 0.1.3
       '@scalar/types': 0.16.2
-      '@scalar/use-codemirror': 0.14.12(@typescript/typescript6@6.0.2)
-      '@scalar/use-hooks': 0.4.7(@typescript/typescript6@6.0.2)
-      '@scalar/use-toasts': 0.10.2(@typescript/typescript6@6.0.2)
-      '@scalar/workspace-store': 0.55.3(@typescript/typescript6@6.0.2)
-      '@vueuse/core': 13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))
-      '@vueuse/integrations': 13.9.0(axios@1.17.0)(focus-trap@7.8.0)(fuse.js@7.4.2)(vue@3.5.39(@typescript/typescript6@6.0.2))
+      '@scalar/use-codemirror': 0.14.12(typescript@6.0.3)
+      '@scalar/use-hooks': 0.4.7(typescript@6.0.3)
+      '@scalar/use-toasts': 0.10.2(typescript@6.0.3)
+      '@scalar/workspace-store': 0.55.3(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@6.0.3))
+      '@vueuse/integrations': 13.9.0(axios@1.17.0)(focus-trap@7.8.0)(fuse.js@7.4.2)(vue@3.5.39(typescript@6.0.3))
       focus-trap: 7.8.0
       fuse.js: 7.4.2
       js-base64: 3.8.1
       jsonc-parser: 3.3.1
       nanoid: 5.1.16
       pretty-ms: 9.3.0
-      radix-vue: 1.9.17(vue@3.5.39(@typescript/typescript6@6.0.2))
+      radix-vue: 1.9.17(vue@3.5.39(typescript@6.0.3))
       set-cookie-parser: 3.1.0
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
       yaml: 2.9.0
       zod: 4.4.3
     transitivePeerDependencies:
@@ -6903,18 +6903,18 @@ snapshots:
     dependencies:
       '@scalar/helpers': 0.9.0
 
-  '@scalar/blocks@0.1.4(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)':
+  '@scalar/blocks@0.1.4(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.6(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)
+      '@scalar/components': 0.27.6(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
-      '@scalar/icons': 0.7.3(@typescript/typescript6@6.0.2)
+      '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/snippetz': 0.9.21
       '@scalar/themes': 0.16.2
       '@scalar/types': 0.16.2
-      '@scalar/workspace-store': 0.55.3(@typescript/typescript6@6.0.2)
+      '@scalar/workspace-store': 0.55.3(typescript@6.0.3)
       '@types/har-format': 1.2.16
       js-base64: 3.8.1
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
@@ -6941,21 +6941,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@scalar/components@0.27.6(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)':
+  '@scalar/components@0.27.6(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/utils': 0.2.10
-      '@floating-ui/vue': 1.1.9(vue@3.5.39(@typescript/typescript6@6.0.2))
+      '@floating-ui/vue': 1.1.9(vue@3.5.39(typescript@6.0.3))
       '@headlessui/tailwindcss': 0.2.2(tailwindcss@4.3.2)
-      '@headlessui/vue': 1.7.23(vue@3.5.39(@typescript/typescript6@6.0.2))
+      '@headlessui/vue': 1.7.23(vue@3.5.39(typescript@6.0.3))
       '@scalar/code-highlight': 0.4.1
       '@scalar/helpers': 0.9.0
-      '@scalar/icons': 0.7.3(@typescript/typescript6@6.0.2)
+      '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/themes': 0.16.2
-      '@scalar/use-hooks': 0.4.7(@typescript/typescript6@6.0.2)
-      '@vueuse/core': 13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))
-      cva: 1.0.0-beta.4(@typescript/typescript6@6.0.2)
-      radix-vue: 1.9.17(vue@3.5.39(@typescript/typescript6@6.0.2))
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      '@scalar/use-hooks': 0.4.7(typescript@6.0.3)
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@6.0.3))
+      cva: 1.0.0-beta.4(typescript@6.0.3)
+      radix-vue: 1.9.17(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
       vue-component-type-helpers: 3.3.7
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -6967,12 +6967,12 @@ snapshots:
 
   '@scalar/helpers@0.9.0': {}
 
-  '@scalar/icons@0.7.3(@typescript/typescript6@6.0.2)':
+  '@scalar/icons@0.7.3(typescript@6.0.3)':
     dependencies:
       '@phosphor-icons/core': 2.1.1
       '@types/node': 24.13.3
       chalk: 5.6.2
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -6988,14 +6988,14 @@ snapshots:
       pathe: 2.0.3
       yaml: 2.9.0
 
-  '@scalar/oas-utils@0.19.4(@typescript/typescript6@6.0.2)':
+  '@scalar/oas-utils@0.19.4(typescript@6.0.3)':
     dependencies:
       '@scalar/helpers': 0.9.0
       '@scalar/themes': 0.16.2
       '@scalar/types': 0.16.2
-      '@scalar/workspace-store': 0.55.3(@typescript/typescript6@6.0.2)
+      '@scalar/workspace-store': 0.55.3(typescript@6.0.3)
       flatted: 3.4.2
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
       yaml: 2.9.0
     transitivePeerDependencies:
       - typescript
@@ -7029,15 +7029,15 @@ snapshots:
       '@scalar/helpers': 0.9.0
       '@scalar/validation': 0.6.0
 
-  '@scalar/sidebar@0.9.29(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)':
+  '@scalar/sidebar@0.9.29(tailwindcss@4.3.2)(typescript@6.0.3)':
     dependencies:
-      '@scalar/components': 0.27.6(@typescript/typescript6@6.0.2)(tailwindcss@4.3.2)
+      '@scalar/components': 0.27.6(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/helpers': 0.9.0
-      '@scalar/icons': 0.7.3(@typescript/typescript6@6.0.2)
+      '@scalar/icons': 0.7.3(typescript@6.0.3)
       '@scalar/themes': 0.16.2
-      '@scalar/use-hooks': 0.4.7(@typescript/typescript6@6.0.2)
-      '@scalar/workspace-store': 0.55.3(@typescript/typescript6@6.0.2)
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      '@scalar/use-hooks': 0.4.7(typescript@6.0.3)
+      '@scalar/workspace-store': 0.55.3(typescript@6.0.3)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
@@ -7078,7 +7078,7 @@ snapshots:
       type-fest: 5.8.0
       zod: 4.4.3
 
-  '@scalar/use-codemirror@0.14.12(@typescript/typescript6@6.0.2)':
+  '@scalar/use-codemirror@0.14.12(typescript@6.0.3)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.10.4
@@ -7094,31 +7094,31 @@ snapshots:
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@replit/codemirror-css-color-picker': 6.3.0(@codemirror/language@6.12.4)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
-  '@scalar/use-hooks@0.4.7(@typescript/typescript6@6.0.2)':
+  '@scalar/use-hooks@0.4.7(typescript@6.0.3)':
     dependencies:
-      '@scalar/use-toasts': 0.10.2(@typescript/typescript6@6.0.2)
+      '@scalar/use-toasts': 0.10.2(typescript@6.0.3)
       '@scalar/validation': 0.6.0
-      '@vueuse/core': 13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))
-      cva: 1.0.0-beta.4(@typescript/typescript6@6.0.2)
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@6.0.3))
+      cva: 1.0.0-beta.4(typescript@6.0.3)
       tailwind-merge: 3.5.0
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
-  '@scalar/use-toasts@0.10.2(@typescript/typescript6@6.0.2)':
+  '@scalar/use-toasts@0.10.2(typescript@6.0.3)':
     dependencies:
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
       vue-sonner: 1.3.2
     transitivePeerDependencies:
       - typescript
 
   '@scalar/validation@0.6.0': {}
 
-  '@scalar/workspace-store@0.54.5(@typescript/typescript6@6.0.2)':
+  '@scalar/workspace-store@0.54.5(typescript@6.0.3)':
     dependencies:
       '@scalar/helpers': 0.8.2
       '@scalar/json-magic': 0.12.16
@@ -7130,12 +7130,12 @@ snapshots:
       '@scalar/validation': 0.6.0
       js-base64: 3.8.1
       type-fest: 5.8.0
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
       yaml: 2.9.0
     transitivePeerDependencies:
       - typescript
 
-  '@scalar/workspace-store@0.55.3(@typescript/typescript6@6.0.2)':
+  '@scalar/workspace-store@0.55.3(typescript@6.0.3)':
     dependencies:
       '@scalar/asyncapi-upgrader': 0.1.2
       '@scalar/helpers': 0.9.0
@@ -7148,7 +7148,7 @@ snapshots:
       '@scalar/validation': 0.6.0
       js-base64: 3.8.1
       type-fest: 5.8.0
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
       yaml: 2.9.0
     transitivePeerDependencies:
       - typescript
@@ -7208,12 +7208,12 @@ snapshots:
       '@shikijs/core': 3.23.0
       '@shikijs/types': 3.23.0
 
-  '@shikijs/twoslash@3.23.0(@typescript/typescript6@6.0.2)':
+  '@shikijs/twoslash@3.23.0(typescript@6.0.3)':
     dependencies:
       '@shikijs/core': 3.23.0
       '@shikijs/types': 3.23.0
-      twoslash: 0.3.9(@typescript/typescript6@6.0.2)
-      typescript: '@typescript/typescript6@6.0.2'
+      twoslash: 0.3.9(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7324,12 +7324,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.7)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.7)
 
-  '@svgr/core@8.1.0(@typescript/typescript6@6.0.2)':
+  '@svgr/core@8.1.0(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.7
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(@typescript/typescript6@6.0.2)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -7340,11 +7340,11 @@ snapshots:
       '@babel/types': 7.29.7
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(@typescript/typescript6@6.0.2))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.7
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.7)
-      '@svgr/core': 8.1.0(@typescript/typescript6@6.0.2)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -7902,10 +7902,10 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.3': {}
 
-  '@tanstack/vue-virtual@3.13.31(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@tanstack/vue-virtual@3.13.31(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@tanstack/virtual-core': 3.17.3
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
 
   '@tree-sitter-grammars/tree-sitter-yaml@0.7.1(tree-sitter@0.22.4)':
     dependencies:
@@ -8219,10 +8219,10 @@ snapshots:
     dependencies:
       '@typescript/old': typescript@6.0.3
 
-  '@typescript/vfs@1.6.4(@typescript/typescript6@6.0.2)':
+  '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:
       debug: 4.4.3
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8372,36 +8372,36 @@ snapshots:
       '@vue/shared': 3.5.39
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.39(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@vue/server-renderer@3.5.39(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.39
       '@vue/shared': 3.5.39
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
 
   '@vue/shared@3.5.39': {}
 
-  '@vueuse/core@10.11.1(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@vueuse/core@10.11.1(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.39(@typescript/typescript6@6.0.2))
-      vue-demi: 0.14.10(vue@3.5.39(@typescript/typescript6@6.0.2))
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@6.0.3))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@vueuse/core@13.9.0(vue@3.5.39(typescript@6.0.3))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 13.9.0
-      '@vueuse/shared': 13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      '@vueuse/shared': 13.9.0(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
 
-  '@vueuse/integrations@13.9.0(axios@1.17.0)(focus-trap@7.8.0)(fuse.js@7.4.2)(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@vueuse/integrations@13.9.0(axios@1.17.0)(focus-trap@7.8.0)(fuse.js@7.4.2)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      '@vueuse/core': 13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))
-      '@vueuse/shared': 13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      '@vueuse/core': 13.9.0(vue@3.5.39(typescript@6.0.3))
+      '@vueuse/shared': 13.9.0(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
     optionalDependencies:
       axios: 1.17.0
       focus-trap: 7.8.0
@@ -8411,16 +8411,16 @@ snapshots:
 
   '@vueuse/metadata@13.9.0': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@vueuse/shared@10.11.1(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.39(@typescript/typescript6@6.0.2))
+      vue-demi: 0.14.10(vue@3.5.39(typescript@6.0.3))
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@13.9.0(vue@3.5.39(@typescript/typescript6@6.0.2))':
+  '@vueuse/shared@13.9.0(vue@3.5.39(typescript@6.0.3))':
     dependencies:
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -8503,11 +8503,6 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
-
-  abitype@1.2.3(@typescript/typescript6@6.0.2)(zod@4.4.3):
-    optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
-      zod: 4.4.3
 
   abitype@1.2.3(typescript@6.0.3)(zod@4.4.3):
     optionalDependencies:
@@ -8803,14 +8798,14 @@ snapshots:
       layout-base: 2.0.1
     optional: true
 
-  cosmiconfig@8.3.6(@typescript/typescript6@6.0.2):
+  cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 6.0.3
 
   crelt@1.0.7: {}
 
@@ -8824,11 +8819,11 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cva@1.0.0-beta.4(@typescript/typescript6@6.0.2):
+  cva@1.0.0-beta.4(typescript@6.0.3):
     dependencies:
       clsx: 2.1.1
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 6.0.3
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
     dependencies:
@@ -10819,21 +10814,6 @@ snapshots:
 
   outvariant@1.4.0: {}
 
-  ox@0.14.30(@typescript/typescript6@6.0.2)(zod@4.4.3):
-    dependencies:
-      '@adraffy/ens-normalize': 1.11.1
-      '@noble/ciphers': 1.3.0
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(@typescript/typescript6@6.0.2)(zod@4.4.3)
-      eventemitter3: 5.0.1
-    optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
-    transitivePeerDependencies:
-      - zod
-
   ox@0.14.30(typescript@6.0.3)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -11058,20 +11038,20 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  radix-vue@1.9.17(vue@3.5.39(@typescript/typescript6@6.0.2)):
+  radix-vue@1.9.17(vue@3.5.39(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.8.0
-      '@floating-ui/vue': 1.1.11(vue@3.5.39(@typescript/typescript6@6.0.2))
+      '@floating-ui/vue': 1.1.11(vue@3.5.39(typescript@6.0.3))
       '@internationalized/date': 3.12.2
       '@internationalized/number': 3.6.7
-      '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(@typescript/typescript6@6.0.2))
-      '@vueuse/core': 10.11.1(vue@3.5.39(@typescript/typescript6@6.0.2))
-      '@vueuse/shared': 10.11.1(vue@3.5.39(@typescript/typescript6@6.0.2))
+      '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(typescript@6.0.3))
+      '@vueuse/core': 10.11.1(vue@3.5.39(typescript@6.0.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.39(typescript@6.0.3))
       aria-hidden: 1.2.6
       defu: 6.1.7
       fast-deep-equal: 3.1.3
       nanoid: 5.1.16
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
 
@@ -11956,11 +11936,11 @@ snapshots:
 
   twoslash-protocol@0.3.9: {}
 
-  twoslash@0.3.9(@typescript/typescript6@6.0.2):
+  twoslash@0.3.9(typescript@6.0.3):
     dependencies:
-      '@typescript/vfs': 1.6.4(@typescript/typescript6@6.0.2)
+      '@typescript/vfs': 1.6.4(typescript@6.0.3)
       twoslash-protocol: 0.3.9
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12100,7 +12080,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-icons@22.5.0(@svgr/core@8.1.0(@typescript/typescript6@6.0.2))(@vue/compiler-sfc@3.5.39):
+  unplugin-icons@22.5.0(@svgr/core@8.1.0(typescript@6.0.3))(@vue/compiler-sfc@3.5.39):
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@iconify/utils': 3.1.4
@@ -12108,7 +12088,7 @@ snapshots:
       local-pkg: 1.2.1
       unplugin: 2.3.11
     optionalDependencies:
-      '@svgr/core': 8.1.0(@typescript/typescript6@6.0.2)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
       '@vue/compiler-sfc': 3.5.39
     transitivePeerDependencies:
       - supports-color
@@ -12170,23 +12150,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  viem@2.55.0(@typescript/typescript6@6.0.2)(zod@4.4.3):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(@typescript/typescript6@6.0.2)(zod@4.4.3)
-      isows: 1.0.7(ws@8.21.0)
-      ox: 0.14.30(@typescript/typescript6@6.0.2)(zod@4.4.3)
-      ws: 8.21.0
-    optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
 
   viem@2.55.0(typescript@6.0.3)(zod@4.4.3):
     dependencies:
@@ -12277,7 +12240,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vocs@2.5.3(@types/react@19.2.17)(@typescript/typescript6@6.0.2)(@vue/compiler-sfc@3.5.39)(axios@1.17.0)(esbuild@0.28.1)(mermaid@11.12.0)(react-dom@19.2.7(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.0.3)(rollup@4.52.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)):
+  vocs@2.5.3(@types/react@19.2.17)(@vue/compiler-sfc@3.5.39)(axios@1.17.0)(esbuild@0.28.1)(mermaid@11.12.0)(react-dom@19.2.7(react@19.2.7))(react-router@7.13.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(rolldown@1.0.3)(rollup@4.52.4)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(waku@1.0.0-beta.6(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react-server-dom-webpack@19.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(webpack@5.108.4(esbuild@0.28.1)))(react@19.2.7)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)):
     dependencies:
       '@base-ui/react': 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@codesandbox/sandpack-react': 2.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -12292,16 +12255,16 @@ snapshots:
       '@mdx-js/rollup': 3.1.1(rollup@4.52.4)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@remix-run/node-fetch-server': 0.13.3
-      '@scalar/api-client': 3.13.3(@typescript/typescript6@6.0.2)(axios@1.17.0)(tailwindcss@4.3.2)
+      '@scalar/api-client': 3.13.3(axios@1.17.0)(tailwindcss@4.3.2)(typescript@6.0.3)
       '@scalar/openapi-parser': 0.28.8
       '@scalar/snippetz': 0.9.21
-      '@scalar/workspace-store': 0.54.5(@typescript/typescript6@6.0.2)
+      '@scalar/workspace-store': 0.54.5(typescript@6.0.3)
       '@shikijs/rehype': 3.23.0
       '@shikijs/transformers': 3.23.0
-      '@shikijs/twoslash': 3.23.0(@typescript/typescript6@6.0.2)
+      '@shikijs/twoslash': 3.23.0(typescript@6.0.3)
       '@shikijs/types': 3.23.0
-      '@svgr/core': 8.1.0(@typescript/typescript6@6.0.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(@typescript/typescript6@6.0.2))
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
       '@tailwindcss/vite': 4.3.2(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
       '@takumi-rs/image-response': 0.62.8
       '@takumi-rs/wasm': 0.62.8
@@ -12348,11 +12311,11 @@ snapshots:
       tailwindcss: 4.3.2
       tailwindcss-logical: 4.2.0(tailwindcss@4.3.2)
       tsx: 4.23.0
-      twoslash: 0.3.9(@typescript/typescript6@6.0.2)
+      twoslash: 0.3.9(typescript@6.0.3)
       unhead: 3.1.7(esbuild@0.28.1)(rolldown@1.0.3)(rollup@4.52.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1))
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      unplugin-icons: 22.5.0(@svgr/core@8.1.0(@typescript/typescript6@6.0.2))(@vue/compiler-sfc@3.5.39)
+      unplugin-icons: 22.5.0(@svgr/core@8.1.0(typescript@6.0.3))(@vue/compiler-sfc@3.5.39)
       urlpattern-polyfill: 10.1.0
       vfile: 6.0.3
       vite-plugin-arraybuffer: 0.1.4
@@ -12428,21 +12391,21 @@ snapshots:
 
   vue-component-type-helpers@3.3.7: {}
 
-  vue-demi@0.14.10(vue@3.5.39(@typescript/typescript6@6.0.2)):
+  vue-demi@0.14.10(vue@3.5.39(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.39(@typescript/typescript6@6.0.2)
+      vue: 3.5.39(typescript@6.0.3)
 
   vue-sonner@1.3.2: {}
 
-  vue@3.5.39(@typescript/typescript6@6.0.2):
+  vue@3.5.39(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.39
       '@vue/compiler-sfc': 3.5.39
       '@vue/runtime-dom': 3.5.39
-      '@vue/server-renderer': 3.5.39(vue@3.5.39(@typescript/typescript6@6.0.2))
+      '@vue/server-renderer': 3.5.39(vue@3.5.39(typescript@6.0.3))
       '@vue/shared': 3.5.39
     optionalDependencies:
-      typescript: '@typescript/typescript6@6.0.2'
+      typescript: 6.0.3
 
   w3c-keyname@2.2.8: {}
 

--- a/site/package.json
+++ b/site/package.json
@@ -26,6 +26,6 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@types/swagger-ui-react": "5.18.0",
-    "typescript": "catalog:"
+    "typescript": "6.0.3"
   }
 }


### PR DESCRIPTION
## Problem

The Vercel docs (`vocs`) build fails during twoslash rendering with:

```
TSVFS: A request was made for .../@typescript/typescript6/lib/lib.es2020.d.ts
but there wasn't a file found in the file map.
```

## Root cause

The default catalog aliases `typescript` → `npm:@typescript/typescript6@6.0.2`, an **API-only shim** that re-exports the real compiler from its `@typescript/old` dep but ships **no `lib.*.d.ts` files** in its own `lib/`. Vocs's `twoslash` uses `@typescript/vfs`, which loads the standard libs from wherever `typescript` resolves — the lib-less shim — so the VFS can't find `lib.es2020.d.ts`. The store even split into `twoslash_typescript@6.0.3` vs `@typescript/vfs_@typescript+typescript6@6.0.2`, matching the "mismatch in the compiler options" the error mentions.

## Fix

Pin the **site** to the real `typescript@6.0.3` (the exact package the shim wraps) instead of the catalog alias. Both `twoslash` and `@typescript/vfs` then bind to the same lib-complete compiler. The library's TS7 setup (`@typescript/native`) is untouched — only the docs site, the sole lib-dependent consumer, changes.

## Verification

`pnpm --filter site build` completes with no TSVFS/twoslash errors.