### PR TITLE
feat: support extensible currencies

### DIFF
--- a/.changeset/extensible-currencies.md
+++ b/.changeset/extensible-currencies.md
@@ -1,5 +1,5 @@
 ---
-'sushi': major
+'sushi': minor
 ---
 
 Allow `Amount` to carry application-defined currency types.

--- a/.changeset/extensible-currencies.md
+++ b/.changeset/extensible-currencies.md
@@ -1,0 +1,14 @@
+---
+'sushi': major
+---
+
+Allow `Amount` to carry application-defined currency types.
+
+`BaseCurrency` now supports string or numeric identifiers while continuing to
+default to `ChainId`. `Amount`, `Price`, and `subtractSlippage` accept the new
+`AnyCurrency` contract, and amount serialization preserves an external
+currency's serialized type. Blockchain-specific APIs and the `Currency` type
+remain constrained to executable Sushi chain IDs.
+
+Application-defined currencies implement `wrap()` like existing currencies and
+may return themselves when no wrapped representation is needed.

--- a/src/generic/currency/amount.ts
+++ b/src/generic/currency/amount.ts
@@ -3,13 +3,10 @@ import * as z from 'zod'
 import { numberToFixed } from '../format/number.js'
 import { Fraction } from '../math/fraction.js'
 import type { BigintIsh } from '../types/bigintish.js'
-import type { Currency } from './currency.js'
-import type {
-  SerializedCurrency,
-  SerializedCurrencySchema,
-} from './serialized-currency.js'
+import type { AnyCurrency, Currency } from './currency.js'
+import type { SerializedCurrency } from './serialized-currency.js'
 
-export type SerializedAmount<TCurrency extends SerializedCurrency> = {
+export type SerializedAmount<TCurrency extends object = SerializedCurrency> = {
   currency: TCurrency
   amount: string
 }
@@ -17,7 +14,7 @@ export type SerializedAmount<TCurrency extends SerializedCurrency> = {
 /**
  * Represents an amount of a particular currency.
  */
-export class Amount<TCurrency extends Currency = Currency> {
+export class Amount<TCurrency extends AnyCurrency = Currency> {
   /** The currency of this amount */
   public readonly currency: TCurrency
 
@@ -36,7 +33,7 @@ export class Amount<TCurrency extends Currency = Currency> {
    * Creates an Amount from a human-readable value, e.g. "1.5".
    * Just a wrapper around viem's `parseUnits` to handle the currency's decimals.
    */
-  public static fromHuman<TCurrency extends Currency>(
+  public static fromHuman<TCurrency extends AnyCurrency>(
     currency: TCurrency,
     human: bigint | number | string,
   ): Amount<TCurrency> {
@@ -47,7 +44,7 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Creates an Amount from a human-readable value, e.g. "1.5".
    */
-  public static tryFromHuman<TCurrency extends Currency>(
+  public static tryFromHuman<TCurrency extends AnyCurrency>(
     currency: TCurrency,
     human: bigint | number | string,
   ): Amount<TCurrency> | undefined {
@@ -68,9 +65,9 @@ export class Amount<TCurrency extends Currency = Currency> {
     )
   }
 
-  private static getRawAmount<TCurrency extends Currency>(
+  private static getRawAmount<TCurrency extends AnyCurrency>(
     _ref: Amount<TCurrency>,
-    other: Amount | bigint | string,
+    other: Amount<AnyCurrency> | bigint | string,
   ): bigint {
     if (other instanceof Amount) {
       return other.amount
@@ -81,7 +78,9 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Adds another Amount or raw value.
    */
-  public add(other: Amount | Fraction | bigint | string): Amount<TCurrency> {
+  public add(
+    other: Amount<AnyCurrency> | Fraction | bigint | string,
+  ): Amount<TCurrency> {
     let add: bigint
 
     if (other instanceof Fraction) {
@@ -104,7 +103,9 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Subtracts another Amount or raw value.
    */
-  public sub(other: Amount | Fraction | bigint | string): Amount<TCurrency> {
+  public sub(
+    other: Amount<AnyCurrency> | Fraction | bigint | string,
+  ): Amount<TCurrency> {
     let sub: bigint
 
     if (other instanceof Fraction) {
@@ -127,7 +128,9 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Multiplies this amount by another amount or raw value.
    */
-  public mul(other: Amount | Fraction | bigint | string): Amount<TCurrency> {
+  public mul(
+    other: Amount<AnyCurrency> | Fraction | bigint | string,
+  ): Amount<TCurrency> {
     if (other instanceof Fraction) {
       return new Amount(
         this.currency,
@@ -164,7 +167,9 @@ export class Amount<TCurrency extends Currency = Currency> {
    * Divides this amount by another Amount or raw value.
    * @returns a {@link Fraction} for a precise fractional result.
    */
-  public divToFraction(other: Amount | Fraction | bigint | string): Fraction {
+  public divToFraction(
+    other: Amount<AnyCurrency> | Fraction | bigint | string,
+  ): Fraction {
     if (other instanceof Fraction) {
       return new Fraction({
         numerator: this.amount * other.denominator,
@@ -179,7 +184,7 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Returns true if this amount > other.
    */
-  public gt(other: Amount | bigint | string): boolean {
+  public gt(other: Amount<AnyCurrency> | bigint | string): boolean {
     const cmp = Amount.getRawAmount(this, other)
     return this.amount > cmp
   }
@@ -187,7 +192,7 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Returns true if this amount >= other.
    */
-  public gte(other: Amount | bigint | string): boolean {
+  public gte(other: Amount<AnyCurrency> | bigint | string): boolean {
     const cmp = Amount.getRawAmount(this, other)
     return this.amount >= cmp
   }
@@ -195,7 +200,7 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Returns true if this amount < other.
    */
-  public lt(other: Amount | bigint | string): boolean {
+  public lt(other: Amount<AnyCurrency> | bigint | string): boolean {
     const cmp = Amount.getRawAmount(this, other)
     return this.amount < cmp
   }
@@ -203,7 +208,7 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Returns true if this amount <= other.
    */
-  public lte(other: Amount | bigint | string): boolean {
+  public lte(other: Amount<AnyCurrency> | bigint | string): boolean {
     const cmp = Amount.getRawAmount(this, other)
     return this.amount <= cmp
   }
@@ -211,14 +216,14 @@ export class Amount<TCurrency extends Currency = Currency> {
   /**
    * Returns true if this amount == other.
    */
-  public eq(other: Amount | bigint | string): boolean {
+  public eq(other: Amount<AnyCurrency> | bigint | string): boolean {
     const cmp = Amount.getRawAmount(this, other)
     return this.amount === cmp
   }
 
-  public toJSON(): SerializedAmount<SerializedCurrency> {
+  public toJSON(): SerializedAmount<ReturnType<TCurrency['toJSON']>> {
     return {
-      currency: this.currency.toJSON(),
+      currency: this.currency.toJSON() as ReturnType<TCurrency['toJSON']>,
       amount: this.amount.toString(),
     } as const
   }
@@ -244,9 +249,9 @@ export class Amount<TCurrency extends Currency = Currency> {
   }
 }
 
-export function serializedAmountSchema<
-  TSchema extends SerializedCurrencySchema,
->(currencySchema: TSchema) {
+export function serializedAmountSchema<TSchema extends z.ZodType>(
+  currencySchema: TSchema,
+) {
   return z.object({
     currency: currencySchema,
     amount: z.string(),

--- a/src/generic/currency/currency.ts
+++ b/src/generic/currency/currency.ts
@@ -51,6 +51,7 @@ export abstract class BaseCurrency<
   ): boolean {
     return (
       this.chainId === other.chainId &&
+      this.id === other.id &&
       this.decimals === other.decimals &&
       this.type === other.type
     )

--- a/src/generic/currency/currency.ts
+++ b/src/generic/currency/currency.ts
@@ -7,7 +7,7 @@ import type { Token } from './token.js'
 export type CurrencyMetadata = Record<string, unknown>
 
 export abstract class BaseCurrency<
-  TChainId extends ChainId = ChainId,
+  TChainId extends string | number = ChainId,
   TMetadata extends CurrencyMetadata = Record<string, unknown>,
   TCurrencyType extends string = string,
   TSerializedCurrency extends object = SerializedCurrency<TMetadata>,
@@ -47,7 +47,7 @@ export abstract class BaseCurrency<
   abstract get id(): ID<TChainId, string, true>
 
   public isSame(
-    other: BaseCurrency<ChainId, CurrencyMetadata, string, object>,
+    other: BaseCurrency<string | number, CurrencyMetadata, string, object>,
   ): boolean {
     return (
       this.chainId === other.chainId &&
@@ -70,3 +70,11 @@ export type Currency<
   TChainId extends ChainId = ChainId,
   TMetadata extends CurrencyMetadata = Record<string, unknown>,
 > = Native<TChainId, TMetadata> | Token<TChainId, string, TMetadata>
+
+/** The open currency contract accepted by generic monetary primitives. */
+export type AnyCurrency = BaseCurrency<
+  string | number,
+  CurrencyMetadata,
+  string,
+  object
+>

--- a/src/generic/currency/extensible-currency.test-d.ts
+++ b/src/generic/currency/extensible-currency.test-d.ts
@@ -1,0 +1,51 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { subtractSlippage } from '../utils/subtract-slippage.js'
+import { Amount } from './amount.js'
+import { BaseCurrency, type Currency } from './currency.js'
+import { Price } from './price.js'
+
+type SerializedPoints = Readonly<{
+  type: 'points'
+  chainId: 'rewards'
+  id: 'rewards:POINTS'
+}>
+
+class PointsCurrency extends BaseCurrency<
+  'rewards',
+  Record<string, never>,
+  'points',
+  SerializedPoints
+> {
+  override readonly type = 'points' as const
+  override readonly isNative = false as const
+  override readonly isToken = false as const
+  override readonly id = 'rewards:POINTS' as const
+
+  public override wrap(): PointsCurrency {
+    return this
+  }
+
+  public override toJSON(): SerializedPoints {
+    return { type: this.type, chainId: this.chainId, id: this.id }
+  }
+}
+
+declare const points: PointsCurrency
+
+describe('external currency extension types', () => {
+  it('preserves external currency and serialization types', () => {
+    const amount = new Amount(points, 1n)
+
+    expectTypeOf(amount).toEqualTypeOf<Amount<PointsCurrency>>()
+    expectTypeOf(amount.toJSON().currency).toEqualTypeOf<SerializedPoints>()
+    expectTypeOf<PointsCurrency>().not.toMatchTypeOf<Currency>()
+
+    expectTypeOf(amount.wrap()).toEqualTypeOf<Amount<PointsCurrency>>()
+    expectTypeOf(Price.fromHuman(points, points, '1')).toEqualTypeOf<
+      Price<PointsCurrency, PointsCurrency>
+    >()
+    expectTypeOf(subtractSlippage(amount, 0.1)).toEqualTypeOf<
+      Amount<PointsCurrency>
+    >()
+  })
+})

--- a/src/generic/currency/extensible-currency.test.ts
+++ b/src/generic/currency/extensible-currency.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import * as z from 'zod'
+import { subtractSlippage } from '../utils/subtract-slippage.js'
+import { Amount, serializedAmountSchema } from './amount.js'
+import { BaseCurrency } from './currency.js'
+import { Price } from './price.js'
+
+type SerializedPointsCurrency = Readonly<{
+  type: 'points'
+  chainId: 'rewards'
+  id: 'rewards:POINTS'
+}>
+
+class PointsCurrency extends BaseCurrency<
+  'rewards',
+  Record<string, never>,
+  'points',
+  SerializedPointsCurrency
+> {
+  override readonly type = 'points' as const
+  override readonly isNative = false as const
+  override readonly isToken = false as const
+  override readonly id = 'rewards:POINTS' as const
+
+  constructor() {
+    super({
+      chainId: 'rewards',
+      decimals: 0,
+      symbol: 'PTS',
+      name: 'Reward Points',
+    })
+  }
+
+  public override wrap(): PointsCurrency {
+    return this
+  }
+
+  public override toJSON(): SerializedPointsCurrency {
+    return { type: this.type, chainId: this.chainId, id: this.id }
+  }
+}
+
+describe('external currency extension contract', () => {
+  const points = new PointsCurrency()
+
+  it('works with Amount without joining the Currency union', () => {
+    const amount = new Amount(points, 100n)
+
+    expect(amount.amount).toBe(100n)
+    expect(amount.currency).toBe(points)
+    expect(amount.wrap().currency).toBe(points)
+    expect(amount.toJSON()).toEqual({
+      currency: points.toJSON(),
+      amount: '100',
+    })
+  })
+
+  it('accepts an external serialized currency schema', () => {
+    const schema = serializedAmountSchema(
+      z.object({
+        type: z.literal('points'),
+        chainId: z.literal('rewards'),
+        id: z.literal('rewards:POINTS'),
+      }),
+    )
+
+    expect(schema.parse(new Amount(points, 100n).toJSON()).amount).toBe('100')
+  })
+
+  it('works with the remaining generic currency utilities', () => {
+    const price = Price.fromHuman(points, points, '1.5')
+    const amount = new Amount(points, 100n)
+
+    expect(price.getQuote(amount).amount).toBe(150n)
+    expect(subtractSlippage(amount, 0.1).amount).toBe(90n)
+  })
+})

--- a/src/generic/currency/extensible-currency.test.ts
+++ b/src/generic/currency/extensible-currency.test.ts
@@ -8,7 +8,7 @@ import { Price } from './price.js'
 type SerializedPointsCurrency = Readonly<{
   type: 'points'
   chainId: 'rewards'
-  id: 'rewards:POINTS'
+  id: `rewards:${string}`
 }>
 
 class PointsCurrency extends BaseCurrency<
@@ -20,9 +20,10 @@ class PointsCurrency extends BaseCurrency<
   override readonly type = 'points' as const
   override readonly isNative = false as const
   override readonly isToken = false as const
-  override readonly id = 'rewards:POINTS' as const
 
-  constructor() {
+  constructor(
+    public override readonly id: `rewards:${string}` = 'rewards:POINTS',
+  ) {
     super({
       chainId: 'rewards',
       decimals: 0,
@@ -53,6 +54,11 @@ describe('external currency extension contract', () => {
       currency: points.toJSON(),
       amount: '100',
     })
+  })
+
+  it('uses the currency id for value identity', () => {
+    expect(points.isSame(new PointsCurrency('rewards:POINTS'))).toBe(true)
+    expect(points.isSame(new PointsCurrency('rewards:OTHER'))).toBe(false)
   })
 
   it('accepts an external serialized currency schema', () => {

--- a/src/generic/currency/price.ts
+++ b/src/generic/currency/price.ts
@@ -1,11 +1,11 @@
 import { Fraction } from '../math/fraction.js'
 import type { BigintIsh } from '../types/bigintish.js'
 import { Amount } from './amount.js'
-import type { Currency } from './currency.js'
+import type { AnyCurrency } from './currency.js'
 
 export class Price<
-  TBase extends Currency,
-  TQuote extends Currency,
+  TBase extends AnyCurrency,
+  TQuote extends AnyCurrency,
 > extends Fraction {
   public readonly base: TBase
   public readonly quote: TQuote
@@ -13,11 +13,10 @@ export class Price<
   /**
    * Creates a Price from a human-readable quote-per-base value, e.g. "1.5".
    */
-  public static fromHuman<TBase extends Currency, TQuote extends Currency>(
-    base: TBase,
-    quote: TQuote,
-    value: string,
-  ): Price<TBase, TQuote> {
+  public static fromHuman<
+    TBase extends AnyCurrency,
+    TQuote extends AnyCurrency,
+  >(base: TBase, quote: TQuote, value: string): Price<TBase, TQuote> {
     if (!value.match(/^\d*\.?\d+$/)) {
       throw new Error(`Invalid price: ${value}`)
     }
@@ -37,7 +36,10 @@ export class Price<
   /**
    * Tries to create a Price from a human-readable quote-per-base value.
    */
-  public static tryFromHuman<TBase extends Currency, TQuote extends Currency>(
+  public static tryFromHuman<
+    TBase extends AnyCurrency,
+    TQuote extends AnyCurrency,
+  >(
     base: TBase,
     quote: TQuote,
     value: string,

--- a/src/generic/currency/token.ts
+++ b/src/generic/currency/token.ts
@@ -28,7 +28,7 @@ export abstract class Token<
   }
 
   public override isSame(
-    other: BaseCurrency<ChainId, CurrencyMetadata, string, object>,
+    other: BaseCurrency<string | number, CurrencyMetadata, string, object>,
   ): boolean {
     return (
       super.isSame(other) &&

--- a/src/generic/types/id.ts
+++ b/src/generic/types/id.ts
@@ -1,7 +1,7 @@
 import type { ChainId } from '../chain/chains.js'
 
 export type ID<
-  TChainId extends ChainId = ChainId,
+  TChainId extends string | number = ChainId,
   TAddress extends string = string,
   TIncludeNative extends boolean = false,
 > =

--- a/src/generic/utils/subtract-slippage.ts
+++ b/src/generic/utils/subtract-slippage.ts
@@ -1,5 +1,5 @@
 import type { Amount } from '../currency/amount.js'
-import type { Currency } from '../currency/currency.js'
+import type { AnyCurrency } from '../currency/currency.js'
 
 /**
  *
@@ -8,7 +8,7 @@ import type { Currency } from '../currency/currency.js'
  *
  * @returns The amount after subtracting the slippage, eg. amount * 0.9 if slippage is 10% (0.1).
  */
-export function subtractSlippage<TCurrency extends Currency>(
+export function subtractSlippage<TCurrency extends AnyCurrency>(
   amount: Amount<TCurrency>,
   slippage: number,
 ) {


### PR DESCRIPTION
## Summary

- allow BaseCurrency and ID to use application-defined string or numeric identifiers while retaining ChainId defaults
- allow Amount, Price, serialization, and subtractSlippage to preserve external currency types
- keep wrap required so currencies without a wrapped representation can return themselves
- keep blockchain-specific Currency and chain helpers constrained to known ChainIds
- add runtime and type coverage for a neutral external currency

## Verification

- pnpm lint:dryrun
- pnpm lint:repo
- pnpm typecheck
- pnpm test:ci (549 passed, 2 skipped)
- pnpm lint:unused
- pnpm build