### PR TITLE
fix: remove Katana blocks subgraph

### DIFF
--- a/.changeset/calm-pandas-rest.md
+++ b/.changeset/calm-pandas-rest.md
@@ -1,0 +1,5 @@
+---
+'sushi': minor
+---
+
+Remove the Katana blocks subgraph configuration.

--- a/src/evm/config/subgraphs/subgraphs/blocks.ts
+++ b/src/evm/config/subgraphs/subgraphs/blocks.ts
@@ -47,7 +47,6 @@ const BLOCKS_OTHER_URLS = {
   [EvmChainId.MANTLE]: `${GOLDSKY_COMMUNITY_HOST}/blocks/mantle/gn`,
   [EvmChainId.SKALE_EUROPA]: `${SKALE_HOST}/sushi/blocks-skale-europa`,
   [EvmChainId.ROOTSTOCK]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/sushiswap/blocks-rootstock/gn`,
-  [EvmChainId.KATANA]: `${SUSHI_DEDICATED_GOLDSKY_HOST}/blocks/katana/gn`,
 } as const satisfies Partial<Record<EvmChainId, string>>
 
 export const getBlocksSubgraphUrl = getSubgraphUrlWrapper({


### PR DESCRIPTION
## Summary
- remove the Katana blocks subgraph URL
- add a minor changeset for the sushi package

## Testing
- pnpm test:ci
- pnpm typecheck
- pnpm exec biome check src/evm/config/subgraphs/subgraphs/blocks.ts .changeset/calm-pandas-rest.md