### PR TITLE
fix: use Robinscan for Robinhood explorer

### DIFF
--- a/.changeset/fuzzy-robins-scan.md
+++ b/.changeset/fuzzy-robins-scan.md
@@ -1,0 +1,5 @@
+---
+'sushi': patch
+---
+
+Update the Robinhood Chain block explorer to Robinscan.

--- a/src/evm/chain/chains.ts
+++ b/src/evm/chain/chains.ts
@@ -497,6 +497,12 @@ const xLayer = /* @__PURE__ */ defineEvmChain(xLayerViem, {
 const robinhood = /* @__PURE__ */ defineEvmChain(robinhoodViem, {
   key: 'robinhood',
   shortName: 'robinhood',
+  blockExplorers: {
+    default: {
+      name: 'Robinscan',
+      url: 'https://robinscan.io',
+    },
+  },
 })
 
 // Testnets


### PR DESCRIPTION
## Summary

- switch Robinhood Chain explorer links to Robinscan
- add a patch changeset for the `sushi` package

## Testing

- `pnpm exec biome check src/evm/chain/chains.ts .changeset/fuzzy-robins-scan.md`
- `pnpm typecheck`
- `git diff --check`